### PR TITLE
Vue floating panel feature

### DIFF
--- a/src/docs/vue/floating-panel/App.vue
+++ b/src/docs/vue/floating-panel/App.vue
@@ -1,0 +1,114 @@
+<template>
+  <header-component />
+  <sidebar-component active-link="Floating Panel" />
+  <main class="main">
+    <h1 class="heading">Floating Panel</h1>
+    <p>
+      The floating panel component is a versatile and customizable UI element that can be easily integrated into web
+      applications. It
+      provides a convenient way to display content in a floating manner, allowing users to interact with it while
+      maintaining its position
+      on the screen. The component can be configured through CSS and offers various options to suit different design
+      requirements.
+    </p>
+    <ul>
+      <li>
+        isOpen: This boolean attribute determines whether the panel is open or closed. When set to true, the panel is
+        visible and accessible
+        to the user. Conversely, when set to false, the panel is hidden from view.
+      </li>
+      <li>
+        CSS Styling: The component can be styled using CSS to match the desired design aesthetic. This includes options to
+        define the
+        panel's dimensions, background color, border, and other visual properties. Without the correct styles, like width,
+        height and
+        position properties, the panel may not work correctly at all, so only the Vue logic is delegated.
+      </li>
+      <li>
+        Positioning: The floating panel component best supports two main CSS position options: fixed and sticky. When the
+        fixed position is
+        used, the panel remains fixed relative to the viewport, regardless of scrolling. This is useful when the panel
+        needs to stay in a
+        specific position on the screen, such as a sidebar or a toolbar. On the other hand, the sticky position allows the
+        panel to stick to
+        a specific position within its parent container as the user scrolls. This is particularly useful when the panel
+        needs to stay within
+        a certain section of the page, such as a header or a footer.
+      </li>
+    </ul>
+    <floating-panel-component is-open class="floating-panel floating-panel--fixed">
+      <h1 class="floating-panel__caption">Fixed Floating Panel</h1>
+      <p>
+        This panel keeps its alignment through position: fixed. Through this alignment it is possible to keep it atop of
+        all other
+        components through minimal CSS configuration.
+      </p>
+      <strong>DRAG ME</strong>
+    </floating-panel-component>
+    <p>Here is an example of a floating panel with position set to sticky. As you can see it is confined to container.</p>
+    <div class="wrap">
+      <floating-panel-component is-open class="floating-panel floating-panel--sticky">
+        <h1 class="floating-panel__caption">Sticky Floating Panel</h1>
+        <p>
+          This panel keeps its alignment through position: sticky. This way it stays within the bounds of the container,
+          unable to ever
+          leave it in a performant way.
+        </p>
+        <strong>DRAG ME</strong>
+      </floating-panel-component>
+    </div>
+    <p>
+      You should use fallthrough attributes, i.e. specifying class directly on the component for the component
+      configuration to work as expected.
+    </p>
+  </main>
+</template>
+
+<script setup lang="ts">
+import HeaderComponent from "../HeaderComponent.vue";
+import SidebarComponent from "../SidebarComponent.vue";
+import FloatingPanelComponent from "../../../modules/vue-components/floating-panel/FloatingPanel.vue";
+</script>
+
+<style scoped>
+.floating-panel {
+  width: 200px;
+  height: 210px;
+  z-index: 5;
+  background-color: #2390bb;
+  color: #ffffff;
+  font-size: 12px;
+  line-height: 22px;
+  border: 5px solid #676767;
+  text-align: center;
+  cursor: grab;
+}
+
+.floating-panel__caption {
+  font-weight: bold;
+  padding: 10px;
+  background-color: #00435a;
+  font-size: 17px;
+}
+
+.floating-panel--sticky {
+  position: sticky;
+}
+
+.floating-panel--fixed {
+  position: sticky;
+  position: fixed;
+  top: calc(40vh - 210px);
+  left: calc(98vw - 200px);
+}
+
+.wrap {
+  background: rgba(73, 37, 37, 0.7);
+  border-radius: 10px;
+  height: 300px;
+}
+
+.main>p,
+li {
+  max-width: 85%;
+}</style>

--- a/src/docs/vue/floating-panel/app.ts
+++ b/src/docs/vue/floating-panel/app.ts
@@ -1,0 +1,4 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+
+createApp(App).mount("#app");

--- a/src/docs/vue/floating-panel/index.html
+++ b/src/docs/vue/floating-panel/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Floating Panel Component</title>
+  <script defer src="./index.js"></script>
+  <script defer src="./floating-panel/index.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>

--- a/src/modules/interfaces/component/floating-panel/types.ts
+++ b/src/modules/interfaces/component/floating-panel/types.ts
@@ -1,0 +1,3 @@
+export interface FloatingPanelConfiguration {
+    isOpen: boolean;
+}

--- a/src/modules/vue-components/floating-panel/FloatingPanel.vue
+++ b/src/modules/vue-components/floating-panel/FloatingPanel.vue
@@ -1,0 +1,50 @@
+<template>
+    <div class="panel" ref="panel" @mousemove="changePosition" :style="panelStyles" v-if="isOpen">
+        <slot></slot>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, reactive, CSSProperties } from "vue";
+import { FloatingPanelConfiguration } from "src/modules/interfaces/component/floating-panel/types";
+
+const props = defineProps<FloatingPanelConfiguration>();
+const panel = ref<HTMLDivElement | null>(null);
+const panelProperties = reactive({
+    panelX: panel.value?.offsetLeft ?? 0,
+    panelY: panel.value?.offsetTop ?? 0,
+    clientX: 0,
+    clientY: 0,
+    dragging: false
+});
+const panelStyles = reactive<CSSProperties>({});
+
+const changePosition = ({ clientX, clientY }: MouseEvent) => {
+    if (!panelProperties.dragging || !props.isOpen) return;
+    panelStyles.left = panelProperties.panelX + clientX - panelProperties.clientX + "px";
+    panelStyles.top = panelProperties.panelY + clientY - panelProperties.clientY + "px";
+};
+
+const onMouseDown = ({ clientX, clientY }: MouseEvent) => {
+    if (!panel.value || !props.isOpen) return;
+    panelProperties.panelX = panel.value.offsetLeft;
+    panelProperties.panelY = panel.value.offsetTop;
+    panelProperties.clientX = clientX;
+    panelProperties.clientY = clientY;
+    panelProperties.dragging = true;
+};
+
+const onMouseUp = () => {
+    panelProperties.dragging = false;
+};
+
+onMounted(() => {
+    window.addEventListener("mouseup", onMouseUp, false);
+    document.addEventListener("mousedown", onMouseDown);
+});
+
+onUnmounted(() => {
+    window.removeEventListener("mouseup", onMouseUp, false);
+    document.removeEventListener("mousedown", onMouseDown);
+});
+</script>

--- a/src/modules/web-components/floating-panel/floatingPanel.ts
+++ b/src/modules/web-components/floating-panel/floatingPanel.ts
@@ -1,5 +1,6 @@
 import { LitElement, html } from "lit";
 import { customElement, queryAssignedElements, property } from "lit/decorators.js";
+import { FloatingPanelConfiguration } from "src/modules/interfaces/component/floating-panel/types";
 
 declare global {
 	interface HTMLElementTagNameMap {
@@ -8,7 +9,7 @@ declare global {
 }
 
 @customElement("floating-panel-component")
-export class FloatingPanelComponent extends LitElement {
+export class FloatingPanelComponent extends LitElement implements FloatingPanelConfiguration {
   @property({ type: Boolean })
   isOpen = false;
 


### PR DESCRIPTION
## Description
This pull request implements the https://github.com/YuraVolk/Js-Library/issues/111 issue, as converting the floating panel to Vue.

## Analysis
The Floating Panel has been converted to Vue through the following steps:
1. The base logic and algorithms were converted to Vue.
2. It was discovered that the difference between Vue component handling and Lit component handling is crucial enough, and the new solution devised was to give fall-through attributes on the component directly to manage styling.
3. The rest of the logic has been implemented to fit the new design idea.
4. The interface that contained isOpen property was moved to a new file.

## Name of script
Floating Panel Component.

## Browser Support
Issue occurred in 
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Opera

Possibly following:
- [x] IE
- [x] Safari
- [x] Safari for IOS
