### PR TITLE
Vue image comparator feature

### DIFF
--- a/src/docs/vue/image-comparator/App.vue
+++ b/src/docs/vue/image-comparator/App.vue
@@ -1,0 +1,60 @@
+<template>
+    <header-component />
+    <sidebar-component active-link="Image Comparator" />
+    <main class="main">
+        <h1 class="heading">Image Comparator</h1>
+        <image-comparator-component class="comparator">
+            <carousel-item-component class="comparator-element">
+                <img :src="image1" alt="Example Image" class="comparator-element__image">
+            </carousel-item-component>
+            <carousel-item-component class="comparator-element">
+                <img :src="image2" alt="Example Image" class="comparator-element__image">
+            </carousel-item-component>
+            <carousel-item-component class="comparator-element">
+                <img :src="image3" alt="Example Image" class="comparator-element__image">
+            </carousel-item-component>
+            <carousel-item-component class="comparator-element">
+                <img :src="image4" alt="Example Image" class="comparator-element__image">
+            </carousel-item-component>
+        </image-comparator-component>
+    </main>
+</template>
+  
+<script setup lang="ts">
+import HeaderComponent from "../HeaderComponent.vue";
+import SidebarComponent from "../SidebarComponent.vue";
+import ImageComparatorComponent from "../../../modules/vue-components/image-comparator/ImageComparator.vue";
+import CarouselItemComponent from "../../../modules/interfaces/generic/carousel/CarouselItem.vue";
+
+import image1 from "../../../assets/img/slide0.png";
+import image2 from "../../../assets/img/slide1.png";
+import image3 from "../../../assets/img/slide2.png";
+import image4 from "../../../assets/img/slide3.png";
+
+defineExpose({ image1, image2, image3, image4 });
+</script>
+
+<style scoped>
+.comparator {
+  display: block;
+  width: 350px;
+  height: 200px;
+  border: 4px solid #333;
+  background-size: cover;
+  background-repeat: no-repeat;
+}
+
+.comparator-element {
+  position: absolute;
+  width: auto;
+  height: auto;
+  overflow: hidden;
+}
+
+.comparator-element__image {
+  display: block;
+  width: 350px;
+  height: 200px;
+  box-sizing: border-box;
+}
+</style>

--- a/src/docs/vue/image-comparator/App.vue
+++ b/src/docs/vue/image-comparator/App.vue
@@ -3,6 +3,17 @@
     <sidebar-component active-link="Image Comparator" />
     <main class="main">
         <h1 class="heading">Image Comparator</h1>
+        <p>
+            The purpose of the image comparator component is to create a visual comparison between two images.
+            The current implementation supports comparing an arbitrary amount of images as demonstrated in the widget below.
+            The base requirement to compare images is to make images absolute positioned and occupy auto width and height.
+            The component allows users to slide a comparison slider horizontally to reveal different portions of the two
+            images. The component is built using. It includes CSS styles for positioning and styling the comparison
+            slider. The component dynamically adjusts the width of the images and the position of the slider based on user
+            interaction. It also handles mouse and pointer events for smooth sliding functionality. The component only gives
+            basic styling, such as a relative wrapper element and required interactions. Other than that, you can achieve full
+            customization only through experimenting with CSS properties.
+        </p>
         <image-comparator-component class="comparator">
             <carousel-item-component class="comparator-element">
                 <img :src="image1" alt="Example Image" class="comparator-element__image">
@@ -17,6 +28,10 @@
                 <img :src="image4" alt="Example Image" class="comparator-element__image">
             </carousel-item-component>
         </image-comparator-component>
+        <p>
+            This component requires you use special carousel item components as children to automatically provide and inject
+            all the element data.
+        </p>
     </main>
 </template>
   

--- a/src/docs/vue/image-comparator/app.ts
+++ b/src/docs/vue/image-comparator/app.ts
@@ -1,0 +1,4 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+
+createApp(App).mount("#app");

--- a/src/docs/vue/image-comparator/index.html
+++ b/src/docs/vue/image-comparator/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Image Comparator Component</title>
+  <script defer src="./index.js"></script>
+  <script defer src="./image-comparator/index.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>

--- a/src/modules/vue-components/backface-carousel/BackfaceCarousel.vue
+++ b/src/modules/vue-components/backface-carousel/BackfaceCarousel.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
-        <div :class="['carousel', !isHorizontal && 'carousel--vertical']">
-            <ul class="carousel-items" :style="carouselStyles">
+        <div :class="['backface-carousel', !isHorizontal && 'backface-carousel--vertical']">
+            <ul class="backface-carousel-items" :style="carouselStyles">
                 <slot></slot>
             </ul>
         </div>
@@ -86,8 +86,8 @@ onUnmounted(() => {
 provide(INJECTED_ELEMENTS_NAME, elements);
 </script>
 
-<style scoped>
-.carousel {
+<style>
+.backface-carousel {
     display: flex;
     width: auto;
     height: 100%;
@@ -98,18 +98,18 @@ provide(INJECTED_ELEMENTS_NAME, elements);
     padding: 20px;
 }
 
-.carousel--vertical {
+.backface-carousel--vertical {
     margin-top: 10%;
     height: 33vw;
     overflow: visible;
 }
 
-.carousel * {
+.backface-carousel * {
     margin: 0 auto;
     flex: 0 0 auto;
 }
 
-.carousel-items {
+.backface-carousel-items {
     width: 40%;
     margin: 0;
     transform-style: preserve-3d;
@@ -118,7 +118,7 @@ provide(INJECTED_ELEMENTS_NAME, elements);
     list-style-type: none;
 }
 
-.carousel-item {
+.backface-carousel-items > * {
     position: relative;
     width: 100%;
     height: auto;
@@ -127,7 +127,7 @@ provide(INJECTED_ELEMENTS_NAME, elements);
     backface-visibility: hidden;
 }
 
-.carousel-item:not(:first-of-type) {
+.backface-carousel-items > *:not(:first-of-type) {
     position: absolute;
     left: 0;
     top: 0;
@@ -135,7 +135,7 @@ provide(INJECTED_ELEMENTS_NAME, elements);
     padding: 0 auto;
 }
 
-.carousel-item>* {
+.backface-carousel-items > * > * {
     width: 100%;
     height: 100%;
 }

--- a/src/modules/vue-components/image-comparator/ImageComparator.vue
+++ b/src/modules/vue-components/image-comparator/ImageComparator.vue
@@ -1,0 +1,105 @@
+<template>
+    <ul class="wrap">
+        <slot></slot>
+        <div
+            v-for="elementKey in Object.keys(elements).slice(1)"
+            class="comparison-slider"
+            :style="imageData[elementKey].style"
+            @mousedown="(e) => onMouseStart(e, elementKey)"
+            @pointerdown="(e) => onMouseStart(e, elementKey)"
+        ></div>
+    </ul>
+</template>
+
+<script setup lang="ts">
+import { CarouselItems, INJECTED_ELEMENTS_NAME } from 'src/modules/interfaces/generic/carousel/carousel.vue';
+import { onMounted, provide, ref, onUnmounted, reactive, computed, CSSProperties } from 'vue';
+
+interface ImageComparisonData {
+    isClicked: boolean;
+    offsetWidth: number;
+    style: CSSProperties;
+}
+
+const elements = ref<CarouselItems>({});
+const imageData = reactive<Record<string, ImageComparisonData>>({});
+const clickedElement = computed(() => Object.keys(elements.value).find((key) => imageData[key].isClicked));
+
+const slide = (elementKey: string, difference: number) => {
+    const element = elements.value[elementKey];
+    const imageComparisonData = imageData[elementKey];
+    element.styles = {
+        width: difference + "px"
+    };
+    imageComparisonData.style.left = difference + "px";
+};
+
+const onMouseStart = (event: Event, elementKey: string) => {
+    event.preventDefault();
+    imageData[elementKey].isClicked = true;
+};
+
+const onMouseMove = (event: MouseEvent | PointerEvent) => {
+    if (!clickedElement.value) return;
+    const { element, styles } = elements.value[clickedElement.value];
+    styles.left = "0";
+    let pos = event.pageX - element.getBoundingClientRect().left - window.scrollX;
+    if (pos < 0) pos = 0;
+    if (pos > imageData[clickedElement.value].offsetWidth) {
+        pos = imageData[clickedElement.value].offsetWidth;
+    }
+
+    slide(clickedElement.value, pos);
+};
+
+const onMouseUp = () => {
+    for (const key of Object.keys(imageData)) imageData[key].isClicked = false;
+};
+
+onMounted(() => {
+    Object.entries(elements.value).forEach(([key, { element: { offsetWidth } }], index, arr) => {
+        imageData[key] = {
+            isClicked: false,
+            offsetWidth,
+            style: {}
+        };
+        slide(key, offsetWidth - (offsetWidth / (arr.length) * (index)));
+    });
+    window.addEventListener("mouseup", onMouseUp, { passive: true });
+    window.addEventListener("pointerup", onMouseUp, { passive: true });
+    window.addEventListener("mousemove", onMouseMove, { passive: true });
+    window.addEventListener("pointermove", onMouseMove, { passive: true });
+});
+
+onUnmounted(() => {
+    window.removeEventListener("mouseup", onMouseUp);
+    window.removeEventListener("pointerup", onMouseUp);
+    window.removeEventListener("mousemove", onMouseMove);
+    window.removeEventListener("pointermove", onMouseMove);
+});
+
+provide(INJECTED_ELEMENTS_NAME, elements);
+</script>
+
+<style scoped>
+.wrap {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}
+
+.comparison-slider {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1;
+    width: 40px;
+    height: 40px;
+    background-color: #333;
+    border-radius: 50%;
+    cursor: ew-resize;
+}
+</style>


### PR DESCRIPTION
## Description
This pull request implements the https://github.com/YuraVolk/Js-Library/issues/129 issue, as converting the image comparator to Vue.
This also fixes the https://github.com/YuraVolk/Js-Library/issues/166 bug which was caused by introduction of scoped styles.

## Analysis
The Image Comparator has been converted to Vue through the following steps:
1. The base HTML and CSS were converted to Vue.
2. The solution devised was to use the existing CarouselItem component to track nested children.
3. The new code logic to supply unique image key to all functions instead of relying on closures was devised.
4. The rest of the logic has been implemented.

In addition, through making styles non-scoped and updating the backface carousel class names the backface carousel bugs in Vue are fixed.

## Name of script
Backface Carousel Component.

## Browser Support
Issue occurred in 
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Opera

Possibly following:
- [x] IE
- [x] Safari
- [x] Safari for IOS
