### PR TITLE
Vue magnifier feature

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,7 +6,8 @@ module.exports = {
         'node_modules',
         '/docs/',
         '/.eslintrc.cjs',
-        '/webpack/'
+        '/webpack/',
+        'hooks/'
     ],
     parserOptions: {
         project: "./tsconfig.json"

--- a/src/docs/lit/magnifier/index.html
+++ b/src/docs/lit/magnifier/index.html
@@ -37,6 +37,14 @@
       </picture>
       <div class="magnifier__glass" data-magnifier-glass></div>
     </image-magnifier-component>
+    <p>
+      Next, you may see a very similar implementation that is called Zooming Image, with a lot of aspects being shared
+      with this implementation. However, there are important algorithmic differences between the two: this implementation
+      is overall less robust and works better when magnifying glass does not appear when not hovered. The other implementation
+      provides a fallback effect that shows an empty background when near to edge or moving from edge, while this implementation
+      may not give such accurate results for edges. This implementation on the other hand is much better for non-rectangular glass
+      shapes, and is overall a perfect implementation for statically visible non-rectangular glass.
+    </p>
   </main>
 </body>
 

--- a/src/docs/vue/SidebarComponent.vue
+++ b/src/docs/vue/SidebarComponent.vue
@@ -36,7 +36,6 @@ interface Links {
 }
 
 const links: Links = importedLinks;
-defineExpose({ links });
 defineProps({
     activeLink: {
         type: String,

--- a/src/docs/vue/backface-carousel/App.vue
+++ b/src/docs/vue/backface-carousel/App.vue
@@ -11,10 +11,9 @@
             directly into the carousel as children nodes without any configuration. The carousel exposes methods to be
             easily controllable, and
             supports both vertical and horizontal placement. The insertion of children is done through the wrapping all
-            images in an automatically
-            configured carousel-item-component. You're required to use these two components in a combination:
-            backface-carousel-component as the
-            wrapper and carousel-item-component as child items.
+            images in an automatically carousel item component. For usage with this concrete carousel, it is highly recommended
+            you use the predefined BackfaceCarouselItem component that gives default styling required for this type of carousel,
+            and give width and height set to 100% for all inner items of the backface carousel item components.
         </p>
         <backface-carousel-component>
             <carousel-item-component>
@@ -88,7 +87,7 @@
 
 <script setup lang="ts">
 import BackfaceCarouselComponent from "../../../modules/vue-components/backface-carousel/BackfaceCarousel.vue";
-import CarouselItemComponent from "../../../modules/interfaces/generic/carousel/CarouselItem.vue";
+import CarouselItemComponent from "../../../modules/vue-components/backface-carousel/BackfaceCarouselItem.vue";
 import HeaderComponent from "../HeaderComponent.vue";
 import SidebarComponent from "../SidebarComponent.vue";
 
@@ -101,3 +100,10 @@ import image6 from "../../../assets/img/slide5.png";
 
 defineExpose({ image1, image2, image3, image4, image5, image6 });
 </script>
+
+<style scoped>
+img {
+    width: 100%;
+    height: 100%;
+}
+</style>

--- a/src/docs/vue/backface-carousel/App.vue
+++ b/src/docs/vue/backface-carousel/App.vue
@@ -97,8 +97,6 @@ import image3 from "../../../assets/img/slide2.png";
 import image4 from "../../../assets/img/slide3.png";
 import image5 from "../../../assets/img/slide4.png";
 import image6 from "../../../assets/img/slide5.png";
-
-defineExpose({ image1, image2, image3, image4, image5, image6 });
 </script>
 
 <style scoped>

--- a/src/docs/vue/color-picker/App.vue
+++ b/src/docs/vue/color-picker/App.vue
@@ -37,7 +37,6 @@ import SidebarComponent from "../SidebarComponent.vue";
 import ColorPickerComponent from "../../../modules/vue-components/color-picker/ColorPicker.vue";
 
 import colorPickerImage from "../../../assets/img/picker.jpg";
-defineExpose({ colorPickerImage });
 </script>
 
 <style scoped>

--- a/src/docs/vue/custom-video/App.vue
+++ b/src/docs/vue/custom-video/App.vue
@@ -36,8 +36,6 @@ import HeaderComponent from "../HeaderComponent.vue";
 import SidebarComponent from "../SidebarComponent.vue";
 import CustomVideoComponent from "../../../modules/vue-components/custom-video/CustomVideo.vue";
 import videoLink from "../../../assets/video/sample-mp4-file-small.mp4";
-
-defineExpose({ videoLink });
 </script>
 
 <style scoped>

--- a/src/docs/vue/gallery-carousel/App.vue
+++ b/src/docs/vue/gallery-carousel/App.vue
@@ -77,8 +77,6 @@ import image3 from "../../../assets/img/slide2.png";
 import image4 from "../../../assets/img/slide3.png";
 import image5 from "../../../assets/img/slide4.png";
 import image6 from "../../../assets/img/slide5.png";
-
-defineExpose({ image1, image2, image3, image4, image5, image6 });
 </script>
   
 <style scoped>

--- a/src/docs/vue/image-comparator/App.vue
+++ b/src/docs/vue/image-comparator/App.vue
@@ -46,8 +46,6 @@ import image1 from "../../../assets/img/slide0.png";
 import image2 from "../../../assets/img/slide1.png";
 import image3 from "../../../assets/img/slide2.png";
 import image4 from "../../../assets/img/slide3.png";
-
-defineExpose({ image1, image2, image3, image4 });
 </script>
 
 <style scoped>

--- a/src/docs/vue/image-comparator/App.vue
+++ b/src/docs/vue/image-comparator/App.vue
@@ -15,22 +15,23 @@
             customization only through experimenting with CSS properties.
         </p>
         <image-comparator-component class="comparator">
-            <carousel-item-component class="comparator-element">
+            <carousel-item-component>
                 <img :src="image1" alt="Example Image" class="comparator-element__image">
             </carousel-item-component>
-            <carousel-item-component class="comparator-element">
+            <carousel-item-component>
                 <img :src="image2" alt="Example Image" class="comparator-element__image">
             </carousel-item-component>
-            <carousel-item-component class="comparator-element">
+            <carousel-item-component>
                 <img :src="image3" alt="Example Image" class="comparator-element__image">
             </carousel-item-component>
-            <carousel-item-component class="comparator-element">
+            <carousel-item-component>
                 <img :src="image4" alt="Example Image" class="comparator-element__image">
             </carousel-item-component>
         </image-comparator-component>
         <p>
             This component requires you use special carousel item components as children to automatically provide and inject
-            all the element data.
+            all the element data. In order to get default styling and configuration out of the box, it is suggested you use
+            the specific to this component ImageComparatorItem that comes in with pre-bundled styles to work correctly.
         </p>
     </main>
 </template>
@@ -39,7 +40,7 @@
 import HeaderComponent from "../HeaderComponent.vue";
 import SidebarComponent from "../SidebarComponent.vue";
 import ImageComparatorComponent from "../../../modules/vue-components/image-comparator/ImageComparator.vue";
-import CarouselItemComponent from "../../../modules/interfaces/generic/carousel/CarouselItem.vue";
+import CarouselItemComponent from "../../../modules/vue-components/image-comparator/ImageComparatorItem.vue";
 
 import image1 from "../../../assets/img/slide0.png";
 import image2 from "../../../assets/img/slide1.png";
@@ -57,13 +58,6 @@ defineExpose({ image1, image2, image3, image4 });
   border: 4px solid #333;
   background-size: cover;
   background-repeat: no-repeat;
-}
-
-.comparator-element {
-  position: absolute;
-  width: auto;
-  height: auto;
-  overflow: hidden;
 }
 
 .comparator-element__image {

--- a/src/docs/vue/magnifier/App.vue
+++ b/src/docs/vue/magnifier/App.vue
@@ -2,47 +2,44 @@
   <header-component />
   <sidebar-component active-link="Backface Carousel" />
   <main class="main">
-      <h1 class="heading">Backface Carousel</h1>
-      <image-magnifier-component>
-        <template #image>
-          
-        </template>
-        <template #glass>
-          
-        </template>
-      </image-magnifier-component>
+    <h1 class="heading">Backface Carousel</h1>
+    <image-magnifier-component class="magnifier" ref="magnifier">
+      <template #image>
+        <img :src="image1" alt="Example Image" />
+      </template>
+      <template #glass>
+        <image-magnifier-glass-component class="magnifier-glass" @glass-move="(e) => magnifier?.onMouseMove(e)">
+        </image-magnifier-glass-component>
+      </template>
+    </image-magnifier-component>
   </main>
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
 import ImageMagnifierComponent from "../../../modules/vue-components/magnifier/Magnifier.vue";
+import ImageMagnifierGlassComponent from "../../../modules/vue-components/magnifier/MagnifierGlass.vue";
 import HeaderComponent from "../HeaderComponent.vue";
 import SidebarComponent from "../SidebarComponent.vue";
 
 import image1 from "../../../assets/img/slide0.png";
 
-defineExpose({ image1 });
+const magnifier = ref<InstanceType<typeof ImageMagnifierComponent> | null>(null);
 </script>
 
 <style scoped>
 .magnifier {
-  position: relative;
-  display: block;
   border: 3px solid #333333;
   width: 370px;
   height: 220px;
 }
 
-.magnifier__glass {
-  position: absolute;
+.magnifier-glass {
   top: -25px;
   left: -25px;
   width: 70px;
   height: 70px;
   border: 2px solid #222;
-  border-radius: 50%;
   cursor: zoom-in;
-  background-repeat: no-repeat;
 }
-
 </style>

--- a/src/docs/vue/magnifier/App.vue
+++ b/src/docs/vue/magnifier/App.vue
@@ -1,18 +1,49 @@
 <template>
-  <header-component />
-  <sidebar-component active-link="Backface Carousel" />
-  <main class="main">
-    <h1 class="heading">Backface Carousel</h1>
-    <image-magnifier-component class="magnifier" ref="magnifier">
-      <template #image>
-        <img :src="image1" alt="Example Image" />
-      </template>
-      <template #glass>
-        <image-magnifier-glass-component class="magnifier-glass" @glass-move="(e) => magnifier?.onMouseMove(e)">
-        </image-magnifier-glass-component>
-      </template>
-    </image-magnifier-component>
-  </main>
+	<header-component />
+	<sidebar-component active-link="Magnifier" />
+	<main class="main">
+		<h1 class="heading">Magnifier</h1>
+		<p>
+			The image magnifier component is a component that allows users to create an image magnifier effect on their web pages. The main
+			configuration is supplied automatically if you're using the correct configuration settings. This component is customizable to the
+			point you can control the magnifier glass programmatically without any issues and give any custom styles without any issues, with all
+			styling being available through CSS. In order to understand how to customize the component, you need to define two templates for two
+			slots: #image slot that contains an image or any content you'd like to zoom, and #glass slot that contains imported image magnifier
+			glass component. Then, in order to ensure correct behavior you need to listen emitted event glass-move and make a call to image
+			magnifier's component onMouseMove, you would need to persist the reference to magnifier through a Vue ref. After this is set up, you'd
+			need to setup the props for the image magnifier component:
+		</p>
+		<ul>
+			<li>zoomScale: A number that defines the scale of the magnified image. The default value is 2.</li>
+			<li>
+				imageSource: A string that defines the image URL for the magnifier, a required value for the setup to work correctly. You may give
+				this a different value from original image, i.e. image increased in quality.
+			</li>
+		</ul>
+    <p>Here is an example of correctly set up component:</p>
+		<image-magnifier-component class="magnifier" ref="magnifier" :image-source="image1">
+			<template #image>
+				<img :src="image1" alt="Example Image" />
+			</template>
+			<template #glass>
+				<image-magnifier-glass-component class="magnifier-glass" @glass-move="(e) => magnifier?.onMouseMove(e)">
+				</image-magnifier-glass-component>
+			</template>
+		</image-magnifier-component>
+    <p>
+      After this default configuration, you're able to fully customize the magnifier glass mouse coordinates, shifts, and 
+      you are able to give any CSS styles to the components. You should use fallthrough attributes on the image magnifier
+      and image magnifier glass components to achieve full styling control.
+    </p>
+    <p>
+      Next, you may see a very similar implementation that is called Zooming Image, with a lot of aspects being shared
+      with this implementation. However, there are important algorithmic differences between the two: this implementation
+      is overall less robust and works better when magnifying glass does not appear when not hovered. The other implementation
+      provides a fallback effect that shows an empty background when near to edge or moving from edge, while this implementation
+      may not give such accurate results for edges. This implementation on the other hand is much better for non-rectangular glass
+      shapes, and is overall a perfect implementation for statically visible non-rectangular glass.
+    </p>
+	</main>
 </template>
 
 <script setup lang="ts">
@@ -29,17 +60,17 @@ const magnifier = ref<InstanceType<typeof ImageMagnifierComponent> | null>(null)
 
 <style scoped>
 .magnifier {
-  border: 3px solid #333333;
-  width: 370px;
-  height: 220px;
+	border: 3px solid #333333;
+	width: 370px;
+	height: 220px;
 }
 
 .magnifier-glass {
-  top: -25px;
-  left: -25px;
-  width: 70px;
-  height: 70px;
-  border: 2px solid #222;
-  cursor: zoom-in;
+	top: -25px;
+	left: -25px;
+	width: 70px;
+	height: 70px;
+	border: 2px solid #222;
+	cursor: zoom-in;
 }
 </style>

--- a/src/docs/vue/magnifier/App.vue
+++ b/src/docs/vue/magnifier/App.vue
@@ -1,0 +1,48 @@
+<template>
+  <header-component />
+  <sidebar-component active-link="Backface Carousel" />
+  <main class="main">
+      <h1 class="heading">Backface Carousel</h1>
+      <image-magnifier-component>
+        <template #image>
+          
+        </template>
+        <template #glass>
+          
+        </template>
+      </image-magnifier-component>
+  </main>
+</template>
+
+<script setup lang="ts">
+import ImageMagnifierComponent from "../../../modules/vue-components/magnifier/Magnifier.vue";
+import HeaderComponent from "../HeaderComponent.vue";
+import SidebarComponent from "../SidebarComponent.vue";
+
+import image1 from "../../../assets/img/slide0.png";
+
+defineExpose({ image1 });
+</script>
+
+<style scoped>
+.magnifier {
+  position: relative;
+  display: block;
+  border: 3px solid #333333;
+  width: 370px;
+  height: 220px;
+}
+
+.magnifier__glass {
+  position: absolute;
+  top: -25px;
+  left: -25px;
+  width: 70px;
+  height: 70px;
+  border: 2px solid #222;
+  border-radius: 50%;
+  cursor: zoom-in;
+  background-repeat: no-repeat;
+}
+
+</style>

--- a/src/docs/vue/magnifier/app.ts
+++ b/src/docs/vue/magnifier/app.ts
@@ -1,0 +1,4 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+
+createApp(App).mount("#app");

--- a/src/docs/vue/magnifier/index.html
+++ b/src/docs/vue/magnifier/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Magnifier Component</title>
+  <script defer src="./index.js"></script>
+  <script defer src="./magnifier/index.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>

--- a/src/modules/interfaces/generic/carousel/CarouselItem.vue
+++ b/src/modules/interfaces/generic/carousel/CarouselItem.vue
@@ -5,25 +5,10 @@
 </template>
 
 <script setup lang="ts">
-import { inject, ref, onMounted, watch } from 'vue';
-import { assertNonUndefined, uid } from "../../../utils";
-import { INJECTED_ELEMENTS_NAME, CarouselItems } from './carousel.vue';
+import { uid } from 'src/modules/utils';
+import { useLinkedItem } from '../hooks/useLinkedItem.vue';
+import { ref } from 'vue';
 
-const id = ref(uid());
 const item = ref<HTMLElement | null>(null);
-const elements = inject<{ value: CarouselItems }>(INJECTED_ELEMENTS_NAME) ?? { value: {} };
-onMounted(() => {
-    assertNonUndefined(item.value);
-    elements.value[id.value] = {
-        element: item.value,
-        styles: {}
-    };
-});
-
-watch(
-    () => elements.value[id.value]?.styles,
-    () => {
-        if (item.value) Object.assign(item.value.style, elements.value[id.value].styles)
-    }
-);
+useLinkedItem(uid, item);
 </script>

--- a/src/modules/interfaces/generic/carousel/carousel.vue.ts
+++ b/src/modules/interfaces/generic/carousel/carousel.vue.ts
@@ -1,6 +1,0 @@
-export const INJECTED_ELEMENTS_NAME = "carouselItems";
-
-export type CarouselItems = Record<string, {
-    element: HTMLElement;
-    styles: Partial<CSSStyleDeclaration>;
-}>;

--- a/src/modules/interfaces/generic/hooks/useLinkedItem.vue.ts
+++ b/src/modules/interfaces/generic/hooks/useLinkedItem.vue.ts
@@ -1,0 +1,35 @@
+import { inject, ref, onMounted, watch, provide, Ref } from 'vue';
+import { assertNonUndefined } from "../../../utils";
+
+const INJECTED_ELEMENTS_NAME = "libraryLinkedItemsRegistry";
+type LinkedVueItems = Record<string, {
+    element: HTMLElement;
+    styles: Partial<CSSStyleDeclaration>;
+}>;
+
+export function useLinkedItem(generateId: () => string, item: Ref<HTMLElement | null>) {
+    const id = ref(generateId());
+    const elements = inject<{ value: LinkedVueItems }>(INJECTED_ELEMENTS_NAME) ?? { value: {} };
+
+    onMounted(() => {
+        assertNonUndefined(item.value);
+        elements.value[id.value] = {
+            element: item.value,
+            styles: {}
+        };
+    });
+
+    watch(
+        () => elements.value[id.value]?.styles,
+        () => {
+            if (item.value) Object.assign(item.value.style, elements.value[id.value].styles);
+        }
+    );
+}
+
+export function useInjectedLinkedItems() {
+    const elements = ref<LinkedVueItems>({});
+    provide(INJECTED_ELEMENTS_NAME, elements);
+
+    return elements;
+}

--- a/src/modules/vue-components/backface-carousel/BackfaceCarousel.vue
+++ b/src/modules/vue-components/backface-carousel/BackfaceCarousel.vue
@@ -14,13 +14,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, provide, onMounted, onUnmounted, reactive, CSSProperties } from "vue";
-import { INJECTED_ELEMENTS_NAME, CarouselItems } from "../../interfaces/generic/carousel/carousel.vue";
+import { ref, onMounted, onUnmounted, reactive, CSSProperties } from "vue";
 import "../../interfaces/generic/carousel/carouselControlStyles.css";
+import { useInjectedLinkedItems } from "src/modules/interfaces/generic/hooks/useLinkedItem.vue";
 
 const props = defineProps<{ isVertical?: boolean }>();
 const isHorizontal = ref(!props.isVertical ?? false);
-const elements = ref<CarouselItems>({});
+const elements = useInjectedLinkedItems();
 const carouselStyles = reactive<CSSProperties>({});
 const currentItem = ref(0);
 const interval = ref<number | undefined>(undefined);
@@ -78,15 +78,14 @@ onMounted(() => {
     }, 250);
     window.addEventListener("resize", setupCarousel);
 });
+
 onUnmounted(() => {
     window.removeEventListener("resize", setupCarousel);
     window.clearInterval(interval.value);
 });
-
-provide(INJECTED_ELEMENTS_NAME, elements);
 </script>
 
-<style>
+<style scoped>
 .backface-carousel {
     display: flex;
     width: auto;
@@ -116,27 +115,5 @@ provide(INJECTED_ELEMENTS_NAME, elements);
     transition: all 0.5s;
     padding: 0;
     list-style-type: none;
-}
-
-.backface-carousel-items > * {
-    position: relative;
-    width: 100%;
-    height: auto;
-    padding: 0;
-    opacity: 0.9999;
-    backface-visibility: hidden;
-}
-
-.backface-carousel-items > *:not(:first-of-type) {
-    position: absolute;
-    left: 0;
-    top: 0;
-    margin: 0 auto;
-    padding: 0 auto;
-}
-
-.backface-carousel-items > * > * {
-    width: 100%;
-    height: 100%;
 }
 </style>

--- a/src/modules/vue-components/backface-carousel/BackfaceCarouselItem.vue
+++ b/src/modules/vue-components/backface-carousel/BackfaceCarouselItem.vue
@@ -1,0 +1,33 @@
+<template>
+    <li class="backface-carousel-item" ref="item">
+        <slot></slot>
+    </li>
+</template>
+
+<script setup lang="ts">
+import { uid } from 'src/modules/utils';
+import { useLinkedItem } from '../../interfaces/generic/hooks/useLinkedItem.vue';
+import { ref } from 'vue';
+
+const item = ref<HTMLElement | null>(null);
+useLinkedItem(uid, item);
+</script>
+
+<style scoped>
+.backface-carousel-item {
+    position: relative;
+    width: 100%;
+    height: auto;
+    padding: 0;
+    opacity: 0.9999;
+    backface-visibility: hidden;
+}
+
+.backface-carousel-item:not(:first-of-type) {
+    position: absolute;
+    left: 0;
+    top: 0;
+    margin: 0 auto;
+    padding: 0 auto;
+}
+</style>

--- a/src/modules/vue-components/custom-video/CustomVideo.vue
+++ b/src/modules/vue-components/custom-video/CustomVideo.vue
@@ -145,8 +145,6 @@ onMounted(() => {
         rangeInputSettings.duration = video.value.duration;
 	};
 });
-
-defineExpose({ playButton, pauseButton, resetButton, muteButton });
 </script>
 
 <style scoped>

--- a/src/modules/vue-components/gallery-carousel/GalleryCarousel.vue
+++ b/src/modules/vue-components/gallery-carousel/GalleryCarousel.vue
@@ -25,8 +25,8 @@
 
 <script setup lang="ts">
 import { GalleryCarouselConfiguration } from 'src/modules/interfaces/component/gallery-carousel/types';
-import { CarouselItems, INJECTED_ELEMENTS_NAME } from 'src/modules/interfaces/generic/carousel/carousel.vue';
-import { computed, provide, ref, createVNode, VNode, onUnmounted, CSSProperties } from 'vue';
+import { useInjectedLinkedItems } from 'src/modules/interfaces/generic/hooks/useLinkedItem.vue';
+import { computed, ref, createVNode, VNode, onUnmounted, CSSProperties } from 'vue';
 
 const props = withDefaults(defineProps<Partial<GalleryCarouselConfiguration>>(), {
     smoothDiametralTransition: true,
@@ -53,7 +53,7 @@ const lastElement = () => {
 };
 
 const currentSlide = ref(props.current);
-const elements = ref<CarouselItems>({});
+const elements = useInjectedLinkedItems();
 const isAnimating = ref(false);
 const interval = ref<number | undefined>();
 
@@ -99,8 +99,6 @@ const changeCurrentSlide = (newSlide: number) => {
 onUnmounted(() => {
     window.clearInterval(interval.value);
 });
-
-provide(INJECTED_ELEMENTS_NAME, elements);
 </script>
 
 <style scoped>

--- a/src/modules/vue-components/image-comparator/ImageComparator.vue
+++ b/src/modules/vue-components/image-comparator/ImageComparator.vue
@@ -12,8 +12,8 @@
 </template>
 
 <script setup lang="ts">
-import { CarouselItems, INJECTED_ELEMENTS_NAME } from 'src/modules/interfaces/generic/carousel/carousel.vue';
-import { onMounted, provide, ref, onUnmounted, reactive, computed, CSSProperties } from 'vue';
+import { useInjectedLinkedItems } from '../../interfaces/generic/hooks/useLinkedItem.vue';
+import { onMounted, onUnmounted, reactive, computed, CSSProperties } from 'vue';
 
 interface ImageComparisonData {
     isClicked: boolean;
@@ -21,7 +21,7 @@ interface ImageComparisonData {
     style: CSSProperties;
 }
 
-const elements = ref<CarouselItems>({});
+const elements = useInjectedLinkedItems();
 const imageData = reactive<Record<string, ImageComparisonData>>({});
 const clickedElement = computed(() => Object.keys(elements.value).find((key) => imageData[key].isClicked));
 
@@ -77,8 +77,6 @@ onUnmounted(() => {
     window.removeEventListener("mousemove", onMouseMove);
     window.removeEventListener("pointermove", onMouseMove);
 });
-
-provide(INJECTED_ELEMENTS_NAME, elements);
 </script>
 
 <style scoped>

--- a/src/modules/vue-components/image-comparator/ImageComparatorItem.vue
+++ b/src/modules/vue-components/image-comparator/ImageComparatorItem.vue
@@ -1,0 +1,23 @@
+<template>
+    <li class="image-comparator-item" ref="item">
+        <slot></slot>
+    </li>
+</template>
+
+<script setup lang="ts">
+import { uid } from 'src/modules/utils';
+import { useLinkedItem } from '../../interfaces/generic/hooks/useLinkedItem.vue';
+import { ref } from 'vue';
+
+const item = ref<HTMLElement | null>(null);
+useLinkedItem(uid, item);
+</script>
+
+<style scoped>
+.image-comparator-item {
+  position: absolute;
+  width: auto;
+  height: auto;
+  overflow: hidden;
+}
+</style>

--- a/src/modules/vue-components/magnifier/Magnifier.vue
+++ b/src/modules/vue-components/magnifier/Magnifier.vue
@@ -1,23 +1,25 @@
 <template>
     <div class="magnifier">
         <slot name="image"></slot>
-        <div class="magnifier__glass">
-            <slot name="glass"></slot>
-        </div>
+        <slot name="glass" ></slot>
     </div>
 </template>
 
 <script setup lang="ts">
+import { useInjectedLinkedItems } from "src/modules/interfaces/generic/hooks/useLinkedItem.vue";
 
+const elements = useInjectedLinkedItems();
+
+const onMouseMove = (event: MouseEvent) => {
+  
+};
+
+defineExpose({ onMouseMove });
 </script>
 
 <style scoped>
 .magnifier {
   position: relative;
-  display: block;
-  border: 3px solid #333333;
-  width: 370px;
-  height: 220px;
 }
 
 .magnifier__glass {

--- a/src/modules/vue-components/magnifier/Magnifier.vue
+++ b/src/modules/vue-components/magnifier/Magnifier.vue
@@ -1,18 +1,62 @@
 <template>
-    <div class="magnifier">
-        <slot name="image"></slot>
-        <slot name="glass" ></slot>
+  <div class="magnifier">
+    <div class="magnifier__image" @mousemove="onMouseMove" ref="image">
+      <slot name="image"></slot>
     </div>
+    <slot name="glass"></slot>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { useInjectedLinkedItems } from "src/modules/interfaces/generic/hooks/useLinkedItem.vue";
+import { onMounted, ref } from "vue";
 
+interface MagnifierConfiguration {
+  imageSource: string;
+  zoomScale?: number;
+}
+
+const props = withDefaults(defineProps<MagnifierConfiguration>(), {
+  zoomScale: 2
+});
 const elements = useInjectedLinkedItems();
+const image = ref<HTMLElement | null>(null);
+
+const moveMagnifier = (x: number, y: number) => {
+  if (!image.value) return;
+  const glass = elements.value["magnifier-glass"];
+  const width = glass.element.offsetWidth / 2,
+    height = glass.element.offsetHeight / 2;
+  if (x > image.value.offsetWidth) {
+    x = image.value.offsetWidth;
+  } else if (x < 0) x = 0;
+  if (y > image.value.offsetHeight) {
+    y = image.value.offsetHeight;
+  } else if (y < 0) y = 0;
+
+  glass.styles = {
+    ...glass.styles,
+    left: `${x - width}px`,
+    top: `${y - height}px`,
+    backgroundPosition: "-" + (x * props.zoomScale - width) + "px -" + (y * props.zoomScale - height) + "px"
+  };
+};
 
 const onMouseMove = (event: MouseEvent) => {
-  
+  if (!image.value) return;
+  event.preventDefault();
+  const rect = image.value.getBoundingClientRect();
+  moveMagnifier(event.pageX - rect.left - window.scrollX, event.pageY - rect.top - window.scrollY);
 };
+
+onMounted(() => {
+  if (!image.value) return;
+  const glass = elements.value["magnifier-glass"];
+  glass.styles = {
+    backgroundImage: `url("${props.imageSource}")`,
+    backgroundSize: `${image.value.offsetWidth * props.zoomScale}px ${image.value.offsetHeight * props.zoomScale}px`
+  };
+});
 
 defineExpose({ onMouseMove });
 </script>
@@ -20,6 +64,11 @@ defineExpose({ onMouseMove });
 <style scoped>
 .magnifier {
   position: relative;
+}
+
+.magnifier__image {
+  width: 100%;
+  height: 100%;
 }
 
 .magnifier__glass {

--- a/src/modules/vue-components/magnifier/Magnifier.vue
+++ b/src/modules/vue-components/magnifier/Magnifier.vue
@@ -1,0 +1,34 @@
+<template>
+    <div class="magnifier">
+        <slot name="image"></slot>
+        <div class="magnifier__glass">
+            <slot name="glass"></slot>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+
+</script>
+
+<style scoped>
+.magnifier {
+  position: relative;
+  display: block;
+  border: 3px solid #333333;
+  width: 370px;
+  height: 220px;
+}
+
+.magnifier__glass {
+  position: absolute;
+  top: -25px;
+  left: -25px;
+  width: 70px;
+  height: 70px;
+  border: 2px solid #222;
+  border-radius: 50%;
+  cursor: zoom-in;
+  background-repeat: no-repeat;
+}
+</style>

--- a/src/modules/vue-components/magnifier/MagnifierGlass.vue
+++ b/src/modules/vue-components/magnifier/MagnifierGlass.vue
@@ -1,0 +1,25 @@
+<template>
+    <div class="magnifier-glass" ref="glass" @mousemove="(e) => emit('glassMove', e)">
+        <slot></slot>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { uid } from 'src/modules/utils';
+import { useLinkedItem } from '../../interfaces/generic/hooks/useLinkedItem.vue';
+import { ref } from 'vue';
+
+const emit = defineEmits<{
+    (e: 'glassMove', event: MouseEvent): void;
+}>();
+const glass = ref<HTMLElement | null>(null);
+useLinkedItem(() => "magnifier-glass", glass);
+</script>
+
+<style scoped>
+.magnifier-glass {
+    position: absolute;
+    border-radius: 50%;
+    background-repeat: no-repeat;
+}
+</style>

--- a/src/modules/vue-components/magnifier/MagnifierGlass.vue
+++ b/src/modules/vue-components/magnifier/MagnifierGlass.vue
@@ -1,5 +1,10 @@
 <template>
-    <div class="magnifier-glass" ref="glass" @mousemove="(e) => emit('glassMove', e)">
+    <div
+        class="magnifier-glass"
+        ref="glass"
+        @pointermove="(e) => emit('glassMove', e)"
+        @mousemove="(e) => emit('glassMove', e)"
+    >
         <slot></slot>
     </div>
 </template>


### PR DESCRIPTION
## Description
This pull request implements the https://github.com/YuraVolk/Js-Library/issues/113 issue, as converting the magnifier to Vue.

## Analysis
The Image Magnifier has been converted to Vue through the following steps:
1. The initial HTML structure has been converted to Vue.
2. Due to the specifics of styling magnifying glass, a refactor to create useLinkedItem composable was required. Image Comparator and Backface Carousel were refactored to use the new composable to keep track of existing items.
3. Magnifying glass was tested to use two slots and its own local component using the new composable was successfully tested.
4. The mouse moving logic was bound through the App.vue and the extended CSS support and programmatic control features have been set up.
5. The rest of the logic has been implemented.
6. Description for Magnifier has been updated both for Lit and Vue to compare it to the Zooming Image.

## Name of script
Magnifier Component.

## Browser Support
Issue occurred in 
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Opera

Possibly following:
- [x] IE
- [x] Safari
- [x] Safari for IOS
