### PR TITLE
Vue menu carousel feature

### DIFF
--- a/src/docs/vue/magnifier/App.vue
+++ b/src/docs/vue/magnifier/App.vue
@@ -20,7 +20,7 @@
 				this a different value from original image, i.e. image increased in quality.
 			</li>
 		</ul>
-    <p>Here is an example of correctly set up component:</p>
+		<p>Here is an example of correctly set up component:</p>
 		<image-magnifier-component class="magnifier" ref="magnifier" :image-source="image1">
 			<template #image>
 				<img :src="image1" alt="Example Image" />
@@ -30,19 +30,19 @@
 				</image-magnifier-glass-component>
 			</template>
 		</image-magnifier-component>
-    <p>
-      After this default configuration, you're able to fully customize the magnifier glass mouse coordinates, shifts, and 
-      you are able to give any CSS styles to the components. You should use fallthrough attributes on the image magnifier
-      and image magnifier glass components to achieve full styling control.
-    </p>
-    <p>
-      Next, you may see a very similar implementation that is called Zooming Image, with a lot of aspects being shared
-      with this implementation. However, there are important algorithmic differences between the two: this implementation
-      is overall less robust and works better when magnifying glass does not appear when not hovered. The other implementation
-      provides a fallback effect that shows an empty background when near to edge or moving from edge, while this implementation
-      may not give such accurate results for edges. This implementation on the other hand is much better for non-rectangular glass
-      shapes, and is overall a perfect implementation for statically visible non-rectangular glass.
-    </p>
+		<p>
+			After this default configuration, you're able to fully customize the magnifier glass mouse coordinates, shifts, and you are able to
+			give any CSS styles to the components. You should use fallthrough attributes on the image magnifier and image magnifier glass
+			components to achieve full styling control.
+		</p>
+		<p>
+			Next, you may see a very similar implementation that is called Zooming Image, with a lot of aspects being shared with this
+			implementation. However, there are important algorithmic differences between the two: this implementation is overall less robust and
+			works better when magnifying glass does not appear when not hovered. The other implementation provides a fallback effect that shows an
+			empty background when near to edge or moving from edge, while this implementation may not give such accurate results for edges. This
+			implementation on the other hand is much better for non-rectangular glass shapes, and is overall a perfect implementation for
+			statically visible non-rectangular glass.
+		</p>
 	</main>
 </template>
 

--- a/src/docs/vue/menu-carousel/App.vue
+++ b/src/docs/vue/menu-carousel/App.vue
@@ -1,0 +1,93 @@
+<template>
+	<header-component />
+	<sidebar-component active-link="Menu Carousel" />
+	<main class="main">
+		<h1 class="heading">Menu Carousel</h1>
+        <p>
+            The menu carousel component represents a 3D carousel in which items are rotated around a circular area
+            that can be defined and whose X/Y dimensions can be changed by user. The carousel accepts a variety of
+            configuration options:
+        </p>
+        <ul>
+            <li>xPos, automatically re-calculated on resize by default.</li>
+            <li>yPos, defines Y size of carousel.</li>
+            <li>xRadius, defines inner circle X radius.</li>
+            <li>yRadius, defines inner circle Y radius.</li>
+            <li>farScale, defines the scale between elements, allowing farther elements to appear smaller.</li>
+            <li>speed, defines the animation speed.</li>
+        </ul>
+        <p>
+            The carousel accepts special carousel item components to keep track of all the elements, and automatically
+            detect width and height. Here's an example of the carousel with all default settings except far scale being
+            set to 0.8:
+        </p>
+		<menu-carousel-component class="carousel" :far-scale="0.8">
+			<carousel-item-component class="carousel-item">
+                <img :src="image1" alt="Example Image">
+            </carousel-item-component>
+            <carousel-item-component class="carousel-item">
+                <img :src="image2" alt="Example Image">
+            </carousel-item-component>
+            <carousel-item-component class="carousel-item">
+                <img :src="image3" alt="Example Image">
+            </carousel-item-component>
+            <carousel-item-component class="carousel-item">
+                <img :src="image4" alt="Example Image">
+            </carousel-item-component>
+            <carousel-item-component class="carousel-item">
+                <img :src="image5" alt="Example Image">
+            </carousel-item-component>
+            <carousel-item-component class="carousel-item">
+                <img :src="image6" alt="Example Image">
+            </carousel-item-component>
+            <carousel-item-component class="carousel-item">
+                <img :src="image1" alt="Example Image">
+            </carousel-item-component>
+            <carousel-item-component class="carousel-item">
+                <img :src="image2" alt="Example Image">
+            </carousel-item-component>
+            <carousel-item-component class="carousel-item">
+                <img :src="image3" alt="Example Image">
+            </carousel-item-component>
+            <carousel-item-component class="carousel-item">
+                <img :src="image4" alt="Example Image">
+            </carousel-item-component>
+            <carousel-item-component class="carousel-item">
+                <img :src="image5" alt="Example Image">
+            </carousel-item-component>
+            <carousel-item-component class="carousel-item">
+                <img :src="image6" alt="Example Image">
+            </carousel-item-component>
+		</menu-carousel-component>
+	</main>
+</template>
+
+<script setup lang="ts">
+import MenuCarouselComponent from "../../../modules/vue-components/menu-carousel/MenuCarousel.vue";
+import CarouselItemComponent from "../../../modules/interfaces/generic/carousel/CarouselItem.vue";
+import HeaderComponent from "../HeaderComponent.vue";
+import SidebarComponent from "../SidebarComponent.vue";
+
+import image1 from "../../../assets/img/slide0.png";
+import image2 from "../../../assets/img/slide1.png";
+import image3 from "../../../assets/img/slide2.png";
+import image4 from "../../../assets/img/slide3.png";
+import image5 from "../../../assets/img/slide4.png";
+import image6 from "../../../assets/img/slide5.png";
+</script>
+
+<style scoped>
+.carousel {
+  width: 100%;
+  height: 60vh;
+}
+
+.carousel-item {
+  width: 18vw;
+}
+
+img {
+    width: 100%;
+    height: 100%;
+}
+</style>

--- a/src/docs/vue/menu-carousel/app.ts
+++ b/src/docs/vue/menu-carousel/app.ts
@@ -1,0 +1,4 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+
+createApp(App).mount("#app");

--- a/src/docs/vue/menu-carousel/index.html
+++ b/src/docs/vue/menu-carousel/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Menu Carousel Component</title>
+  <script defer src="./index.js"></script>
+  <script defer src="./menu-carousel/index.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>

--- a/src/modules/interfaces/component/menu-carousel/types.ts
+++ b/src/modules/interfaces/component/menu-carousel/types.ts
@@ -1,0 +1,37 @@
+export abstract class MenuCarouselInternalItem {
+    image: HTMLElement;
+    fullWidth: number;
+    fullHeight: number;
+    width?: number;
+    height?: number;
+    x?: number;
+    y?: number;
+    scale?: number;
+
+    constructor(image: HTMLElement) {
+        this.image = image;
+        this.fullWidth = image.clientWidth;
+        this.fullHeight = image.clientHeight;
+    }
+
+    moveTo(x: number, y: number, scale: number) {
+        this.width = this.fullWidth * scale;
+        this.height = this.fullHeight * scale;
+        this.x = x;
+        this.y = y;
+        this.scale = scale;
+        this.setMovingStyle(x, y, scale);
+    }
+
+    abstract initStyles(): this;
+    abstract setMovingStyle(x: number, y: number, scale: number): void;
+}
+
+export interface MenuCarouselConfiguration {
+    xPos?: number;
+    yPos: number;
+    xRadius?: number;
+    yRadius: number;
+    farScale: number;
+    speed: number;
+}

--- a/src/modules/interfaces/generic/hooks/useLinkedItem.vue.ts
+++ b/src/modules/interfaces/generic/hooks/useLinkedItem.vue.ts
@@ -6,6 +6,7 @@ type LinkedVueItems = Record<string, {
     element: HTMLElement;
     styles: Partial<CSSStyleDeclaration>;
 }>;
+export type LinkedVueItem = LinkedVueItems[string];
 
 export function useLinkedItem(generateId: () => string, item: Ref<HTMLElement | null>) {
     const id = ref(generateId());

--- a/src/modules/vue-components/menu-carousel/MenuCarousel.vue
+++ b/src/modules/vue-components/menu-carousel/MenuCarousel.vue
@@ -1,0 +1,159 @@
+<template>
+    <ul ref="carousel">
+        <slot></slot>
+        <li class="carousel-controls">
+            <button class="carousel-controls__previous-button" @click="goBack"></button>
+            <button class="carousel-controls__next-button" @click="goForward"></button>
+        </li>
+    </ul>
+</template>
+
+<script setup lang="ts">
+import { CarouselDirection } from "src/modules/interfaces/generic/carousel/carousel";
+import "../../interfaces/generic/carousel/carouselControlStyles.css";
+import { MenuCarouselConfiguration, MenuCarouselInternalItem } from 'src/modules/interfaces/component/menu-carousel/types';
+import { useInjectedLinkedItems, LinkedVueItem } from 'src/modules/interfaces/generic/hooks/useLinkedItem.vue';
+import { assertNonUndefinedDevOnly } from "src/modules/utils";
+import { onMounted, onUnmounted, reactive, ref } from 'vue';
+
+const props = withDefaults(defineProps<Partial<MenuCarouselConfiguration>>(), {
+    yPos: 112,
+    yRadius: 128,
+    farScale: 0.9,
+    speed: 0.11
+});
+const rotation = ref(Math.PI / 2);
+const destRotation = ref(Math.PI / 2);
+const frameTimer = ref<number | undefined>();
+const xRadius = ref(props.xRadius);
+const yRadius = ref(props.yRadius);
+const xPos = ref(props.xPos);
+const yPos = ref(props.yPos);
+
+const carousel = ref<HTMLElement | null>(null);
+const elements = useInjectedLinkedItems();
+const items = reactive<Item[]>([]);
+class Item extends MenuCarouselInternalItem {
+    constructor(private elementData: LinkedVueItem) {
+        super(elementData.element);
+    }
+
+    initStyles() {
+        this.elementData.styles = {
+            position: "absolute"
+        };
+        return this;
+    }
+
+    setMovingStyle(x: number, y: number, scale: number) {
+        this.elementData.styles = {
+            ...this.elementData.styles,
+            width: this.width + "px",
+            left: x + "px",
+            top: y + "px",
+            zIndex: String((scale * 100) | 0)
+        };
+    }
+}
+
+const rotateItem = (itemIndex: number, rotation: number) => {
+    const item = items[itemIndex];
+    const sin = Math.sin(rotation);
+    const scale = props.farScale + (1 - props.farScale) * (sin + 1) * 0.5;
+    assertNonUndefinedDevOnly(xPos.value);
+    assertNonUndefinedDevOnly(xRadius.value);
+    item.moveTo(
+        xPos.value + scale * (Math.cos(rotation) * xRadius.value - item.fullWidth / 2),
+        yPos.value + scale * sin * yRadius.value + yPos.value / 2.3,
+        scale
+    );
+};
+
+const playFrame = () => {
+    const change = destRotation.value - rotation.value;
+    if (Math.abs(change) <= 0) {
+        rotation.value = destRotation.value;
+        window.clearTimeout(frameTimer.value);
+        frameTimer.value = undefined;
+    } else {
+        rotation.value += change * props.speed;
+        scheduleNextFrame();
+    }
+
+    carouselRender();
+};
+
+const scheduleNextFrame = () => {
+    frameTimer.value = window.setTimeout(() => {
+        playFrame();
+    }, 32);
+};
+
+const go = (count: number) => {
+    destRotation.value += ((2 * Math.PI) / items.length) * count;
+    if (frameTimer.value === undefined) scheduleNextFrame();
+};
+
+const carouselRender = () => {
+    const count = items.length;
+    const spacing = (2 * Math.PI) / count;
+    let radians = rotation.value;
+    for (let i = 0; i < count; i++) {
+        rotateItem(i, radians);
+        radians += spacing;
+    }
+};
+
+const setupCarousel = () => {
+    if (!carousel.value) return;
+    xPos.value ??= carousel.value.offsetWidth * 0.5;
+    yPos.value = carousel.value.offsetHeight * 0.1;
+    xRadius.value ??= carousel.value.offsetWidth / 2.3;
+    yRadius.value = carousel.value.offsetHeight / 6;
+    items.splice(0, items.length);
+    for (const image of Object.values(elements.value)) {
+        image.element.removeAttribute("style");
+        items.push(new Item(image).initStyles());
+    }
+
+    carouselRender();
+};
+
+const onResize = () => {
+    xRadius.value = undefined;
+    xPos.value = undefined;
+    setupCarousel();
+};
+
+const goBack = () => {
+    go(CarouselDirection.BACKWARDS);
+};
+
+const goForward = () => {
+    go(CarouselDirection.FORWARDS);
+};
+
+onMounted(() => {
+    setupCarousel();
+    window.addEventListener("resize", onResize);
+});
+
+onUnmounted(() => {
+    window.removeEventListener("resize", onResize);
+    window.clearTimeout(frameTimer.value);
+});
+</script>
+
+<style scoped>
+.carousel {
+    position: relative;
+    overflow: hidden;
+    padding: 0;
+    list-style-type: none;
+}
+
+.carousel-controls {
+    z-index: 999;
+    top: 80%;
+}
+</style>

--- a/src/modules/web-components/menu-carousel/menuCarousel.ts
+++ b/src/modules/web-components/menu-carousel/menuCarousel.ts
@@ -6,6 +6,7 @@ import {
 } from "lit/decorators.js";
 import { assertNonUndefinedDevOnly } from "../../utils";
 import { carouselControlsStyles } from "src/modules/interfaces/generic/carousel/carousel.lit";
+import { MenuCarouselConfiguration, MenuCarouselInternalItem } from "src/modules/interfaces/component/menu-carousel/types";
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -13,39 +14,23 @@ declare global {
   }
 }
 
-class Item {
-  image: HTMLElement;
-  fullWidth: number;
-  fullHeight: number;
-  width?: number;
-  height?: number;
-  x?: number;
-  y?: number;
-  scale?: number;
-  moveTo: (x: number, y: number, scale: number) => void;
+class Item extends MenuCarouselInternalItem {
+  initStyles() {
+    this.image.style.position = "absolute";
+    return this;
+  }
 
-  constructor(image: HTMLElement) {
-    this.image = image;
-    this.fullWidth = image.clientWidth;
-    this.fullHeight = image.clientHeight;
-    image.style.position = "absolute";
-    this.moveTo = function (x, y, scale) {
-      this.width = this.fullWidth * scale;
-      this.height = this.fullHeight * scale;
-      this.x = x;
-      this.y = y;
-      this.scale = scale;
-      const style = this.image.style;
-      style.width = this.width + "px";
-      style.left = x + "px";
-      style.top = y + "px";
-      style.zIndex = String((scale * 100) | 0);
-    };
+  setMovingStyle(x: number, y: number, scale: number) {
+    const style = this.image.style;
+    style.width = this.width + "px";
+    style.left = x + "px";
+    style.top = y + "px";
+    style.zIndex = String((scale * 100) | 0);
   }
 }
 
 @customElement("menu-carousel-component")
-export class MenuCarouselComponent extends LitElement {
+export class MenuCarouselComponent extends LitElement implements MenuCarouselConfiguration {
   static styles = carouselControlsStyles;
 
   @state()
@@ -140,7 +125,7 @@ export class MenuCarouselComponent extends LitElement {
     this.yPos = this._carousel.offsetHeight * 0.1;
     this.xRadius ??= this._carousel.offsetWidth / 2.3;
     this.yRadius = this._carousel.offsetHeight / 6;
-    this._items = this._images.map((item) => new Item(item));
+    this._items = this._images.map((item) => new Item(item).initStyles());
     this.carouselRender();
   }
 


### PR DESCRIPTION
## Description
This pull request implements the https://github.com/YuraVolk/Js-Library/issues/107 issue, as converting the magnifier to Vue.

## Analysis
The Menu Carousel has been converted to Vue through the following steps:
1. The initial HTML structure and initial props were converted to Vue.
2. An interface was isolated to a new file, an abstract class for internal item tracking was created, Lit version was modified to use the abstract class, Vue version implemented the abstract class.
3. Local copies of props through refs were created.
4. Full logic has been implemented.
5. Minor algorithmic fixes due to calculation differences have been included.

## Name of script
Menu Carousel Component.

## Browser Support
Issue occurred in 
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Opera

Possibly following:
- [x] IE
- [x] Safari
- [x] Safari for IOS
