### PR TITLE
Vue table filtering feature

### DIFF
--- a/src/docs/vue/table-filtering/App.vue
+++ b/src/docs/vue/table-filtering/App.vue
@@ -3,17 +3,84 @@
 	<sidebar-component active-link="Table Filtering" />
 	<main class="main">
 		<h1 class="heading">Table Filtering</h1>
-		
+		<p>
+			The table filtering component is a component that allows you to add filters to a table, through getting all unique values in a table
+			column and allowing the user to cross out certain values. While this is rarely needed, it is still a useful widget to have when you're
+			displaying real tabular data, as this component allows you to easily customize the table filtering process, making it very easy to
+			setup and configure: you need to use three provided components in conjunction for it to work correctly. Firstly, you should create a
+			table filtering component, and get the component as a ref. Next, you need to create base table structure: two exceptions is to use
+			table filtering header instead of normal table headers and table filtering row instead of normal table rows. In order to configure
+			clicking on headers, attach a click event listener to each header and call the table component's exposed onHeaderClicked function:
+			pass a zero-based index as the parameter. Then you can attach an event listener to the tbody and make it call table component's
+			exposed closeSelect method. The filtering works through the text contents of the td elements, so ensure table cells are having a text
+			content. In order to configure non-filterable headers, just omit click listeners for specific headers.
+		</p>
+		<p>Here you can see an example of this component with filtering for all headers enabled:</p>
+		<table-filtering-component class="table-wrap" ref="table">
+			<table class="table">
+				<thead class="table-head">
+					<table-filtering-header-component class="table-head__heading" @click="() => onHeaderClicked(0)"
+						>Name</table-filtering-header-component
+					>
+					<table-filtering-header-component class="table-head__heading" @click="() => onHeaderClicked(1)"
+						>Country</table-filtering-header-component
+					>
+					<table-filtering-header-component class="table-head__heading" @click="() => onHeaderClicked(2)"
+						>Specialty</table-filtering-header-component
+					>
+				</thead>
+				<tbody class="table-body" @click="onTableBodyClicked">
+					<table-filtering-row-component class="table-body-row">
+						<td class="table-body-row__cell">John</td>
+						<td class="table-body-row__cell">Austria</td>
+						<td class="table-body-row__cell">Designer</td>
+					</table-filtering-row-component>
+					<table-filtering-row-component class="table-body-row">
+						<td class="table-body-row__cell">Mary</td>
+						<td class="table-body-row__cell">Ireland</td>
+						<td class="table-body-row__cell">Architect</td>
+					</table-filtering-row-component>
+					<table-filtering-row-component class="table-body-row">
+						<td class="table-body-row__cell">Jane</td>
+						<td class="table-body-row__cell">Australia</td>
+						<td class="table-body-row__cell">QA Tester</td>
+					</table-filtering-row-component>
+					<table-filtering-row-component class="table-body-row">
+						<td class="table-body-row__cell">Mark</td>
+						<td class="table-body-row__cell">Russia</td>
+						<td class="table-body-row__cell">Game Developer</td>
+					</table-filtering-row-component>
+					<table-filtering-row-component class="table-body-row">
+						<td class="table-body-row__cell">Paul</td>
+						<td class="table-body-row__cell">France</td>
+						<td class="table-body-row__cell">Backend Developer</td>
+					</table-filtering-row-component>
+				</tbody>
+			</table>
+		</table-filtering-component>
 	</main>
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
 import HeaderComponent from "../HeaderComponent.vue";
 import SidebarComponent from "../SidebarComponent.vue";
-import TableFilteringComponent from "../../../modules/vue-components/sticky-header/StickyHeader.vue";
+import TableFilteringComponent from "../../../modules/vue-components/table-filtering/TableFiltering.vue";
+import TableFilteringHeaderComponent from "../../../modules/vue-components/table-filtering/TableFilteringHeader.vue";
+import TableFilteringRowComponent from "../../../modules/vue-components/table-filtering/TableFilteringRow.vue";
 
 import filterIcon from "../../../assets/svg/filter-icon.svg";
 const filterIconUrl = `url("${filterIcon}")`;
+
+const table = ref<InstanceType<typeof TableFilteringComponent> | null>(null);
+
+const onHeaderClicked = (headerIndex: number) => {
+	table.value?.onHeaderClicked(headerIndex);
+};
+
+const onTableBodyClicked = () => {
+	table.value?.closeSelect();
+};
 </script>
 
 <style scoped>
@@ -37,7 +104,7 @@ const filterIconUrl = `url("${filterIcon}")`;
 	width: 15px;
 	height: 15px;
 	margin-left: 5px;
-	background-image: v-bind('filterIconUrl');
+	background-image: v-bind("filterIconUrl");
 	background-repeat: no-repeat;
 	background-size: cover;
 	transform: translateY(12.5%);

--- a/src/modules/vue-components/table-filtering/TableFiltering.vue
+++ b/src/modules/vue-components/table-filtering/TableFiltering.vue
@@ -1,14 +1,122 @@
 <template>
-    <div class="wrap">
-        <slot></slot>
-    </div>
-
+	<div class="wrap" ref="wrap">
+		<slot></slot>
+		<div
+			class="wrap-select"
+			v-if="openSelect"
+			:style="{
+				top: `${openSelect.top}px`,
+				left: `${openSelect.left}px`,
+				width: `${openSelect.width}px`,
+				height: `${openSelect.height}px`
+			}"
+		>
+			<div
+				v-for="option in openSelect.options"
+				class="wrap-select__option"
+				:class="{
+                    'wrap-select__option--crossed' :excludedCriteria[openSelect.index].includes(option)
+                }"
+				@click="() => toggleCriterion(option)"
+				v-text="option"
+			></div>
+		</div>
+	</div>
 </template>
 
 <script setup lang="ts">
+import { TableSelectInformation } from "src/modules/interfaces/component/table-filtering/types";
+import { LinkedVueItem, useInjectedLinkedItems } from "src/modules/interfaces/generic/hooks/useLinkedItem.vue";
+import { assertNonUndefined } from "src/modules/utils";
+import { computed, onMounted, ref } from "vue";
 
+const wrap = ref<HTMLElement | null>(null);
+const elements = useInjectedLinkedItems();
+const elementsAccessors = computed(() => {
+	const headers: LinkedVueItem[] = [],
+		rows: LinkedVueItem[] = [];
+	for (const [key, value] of Object.entries(elements)) {
+		if (key.startsWith("table-header-")) {
+			headers.push(value);
+		} else if (key.startsWith("table-row-")) rows.push(value);
+	}
+
+	return { headers, rows };
+});
+
+const openSelect = ref<TableSelectInformation | undefined>();
+const excludedCriteria = ref<Array<string | null>[]>([]);
+
+const toggleCriterion = (option: string) => {
+    assertNonUndefined(openSelect.value);
+    const index = openSelect.value.index;
+    const newExcludedCriteria = [...excludedCriteria.value];
+    if (newExcludedCriteria[index].includes(option)) {
+		newExcludedCriteria[index].splice(newExcludedCriteria[index].indexOf(option), 1);
+	} else newExcludedCriteria[index].push(option);
+
+    excludedCriteria.value = newExcludedCriteria;
+    updateExcludedRows();
+};
+
+const updateExcludedRows = () => {
+    for (const row of elementsAccessors.value.rows) {
+        if (Array.from(row.element.children).some((element, i) => excludedCriteria.value[i].includes(element.textContent ?? ""))) {
+            row.styles = {
+                display: "none"
+            };
+        } else {
+            row.styles = {
+                display: "revert"
+            };
+        }
+    }
+};
+
+const onHeaderClicked = (index: number) => {
+	if (!wrap.value) return;
+	const headerRect = elementsAccessors.value.headers[index].element.getBoundingClientRect();
+	const wrapRect = wrap.value.getBoundingClientRect();
+	const top = headerRect.top - wrapRect.top,
+		left = headerRect.left - wrapRect.left;
+
+	openSelect.value = {
+		index,
+		top,
+		left,
+		width: headerRect.width,
+		height: headerRect.height,
+		options: [...new Set(elementsAccessors.value.rows.map(({ element }) => element.children[index].textContent ?? ""))]
+	};
+};
+
+const closeSelect = () => {
+    openSelect.value = undefined;
+};
+
+onMounted(() => {
+    excludedCriteria.value =  Array.from({ length: elementsAccessors.value.headers.length }, () => []);
+});
+
+defineExpose({ onHeaderClicked, closeSelect });
 </script>
 
 <style scoped>
+.wrap {
+	position: relative;
+}
 
+.wrap-select {
+	position: absolute;
+}
+
+.wrap-select__option {
+	background-color: #333;
+	height: inherit;
+	cursor: pointer;
+}
+
+.wrap-select__option--crossed {
+	text-decoration: line-through;
+}
 </style>


### PR DESCRIPTION
## Description
This pull request implements the https://github.com/YuraVolk/Js-Library/issues/120 issue, as converting the table filtering component to Vue.

## Analysis
The Table Filtering has been converted to Vue through the following steps:
1. Base HTML and CSS were converted to Vue.
2. Open select interface was moved to a new file.
3. HTML rendering for the interface was adapted to Vue.
4. Due to the nature of how Vue differs from Lit, the props were omitted entirely, and a different implementation using the root component configuring click listeners and defineExpose was used.
5. The rest of the simplified logic has been converted to Vue.

## Name of script
Table Filtering Component.

## Browser Support
Issue occurred in 
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Opera

Possibly following:
- [x] IE
- [x] Safari
- [x] Safari for IOS
