### PR TITLE
Vue typing text feature

### DIFF
--- a/src/docs/lit/typing-text/index.html
+++ b/src/docs/lit/typing-text/index.html
@@ -35,7 +35,7 @@
             <li>eachLesserAsSpan, allows to make each letter a separate span if needed, as such allows to create more
                 complex animations. Disabled by default.</li>
         </ul>
-        <p>In the bottom of a page you can see a toast with external CSS styling:</p>
+        <p>In the bottom of a page you can see a typing text with external CSS styling:</p>
         <typing-text-component repetitions="9999" unTypingSpeed="15"
             strings="Nulla facilisi. Cras venenatis nulla non erat luctus ultrices. In facilisis tincidunt tristique. Curabitur lobortis sapien a metus lobortis, et lobortis nunc suscipit. Fusce orci mauris, bibendum et vehicula ac, fringilla at elit.;Lorem ipsum dolor sit amet consectetur adipisicing elit. Officia, atque nam! Perferendis non, deleniti tempore soluta magnam expedita nulla? Est repudiandae error rerum dolorum dolor ducimus ex tempore aut temporibus.">
             <pre class="typing-text"> </pre>

--- a/src/docs/vue/typing-text/App.vue
+++ b/src/docs/vue/typing-text/App.vue
@@ -1,0 +1,68 @@
+<template>
+	<header-component />
+	<sidebar-component active-link="Typing Text" />
+	<main class="main">
+		<h1 class="heading">Typing Text</h1>
+		<p>
+			The typing text, or typewriter text effect is an interesting effect to add to your website. This component represents a visually
+			appealing self-typing text effect that firstly erases any existing text and then types the new text. Through configuration options you
+			may tweak the default settings and even apply animation to the text. This component accepts the following props
+		</p>
+		<ul>
+			<li>strings, specifies the phrase list, with semicolon separated sentences. Empty by default.</li>
+			<li>repetitions, allows you to repeat and cycle through phrases by the number specified. Defaults to 1.</li>
+			<li>interval, sets the initial delay and interval between the text animation.</li>
+			<li>typingSpeed, sets the speed at which letters are typed in milliseconds, defaults to 35.</li>
+			<li>unTypingSpeed, an optional number that sets the speed at which letters are deleted in milliseconds, defaults to 35.</li>
+		</ul>
+		<p>In the bottom of a page you can see a typing text with external CSS styling:</p>
+		<typing-text-component
+			class="typing-text"
+			:repetitions="Infinity"
+			:unTypingSpeed="15"
+			:strings="[
+				'Nulla facilisi. Cras venenatis nulla non erat luctus ultrices. In facilisis tincidunt tristique. Curabitur lobortis sapien a metus lobortis, et lobortis nunc suscipit. Fusce orci mauris, bibendum et vehicula ac, fringilla at elit.',
+				'Lorem ipsum dolor sit amet consectetur adipisicing elit. Officia, atque nam! Perferendis non, deleniti tempore soluta magnam expedita nulla? Est repudiandae error rerum dolorum dolor ducimus ex tempore aut temporibus.'
+			]"
+		></typing-text-component>
+		<p>And here is an animated version of this text:</p>
+		<typing-text-component
+			class="typing-text typing-text--animated"
+			:repetitions="Infinity"
+			:unTypingSpeed="15"
+			:strings="[
+				'',
+				'Nulla facilisi. Cras venenatis nulla non erat luctus ultrices. In facilisis tincidunt tristique. Curabitur lobortis sapien a metus lobortis, et lobortis nunc suscipit. Fusce orci mauris, bibendum et vehicula ac, fringilla at elit.',
+				'Lorem ipsum dolor sit amet consectetur adipisicing elit. Officia, atque nam! Perferendis non, deleniti tempore soluta magnam expedita nulla? Est repudiandae error rerum dolorum dolor ducimus ex tempore aut temporibus.'
+			]"
+		></typing-text-component>
+	</main>
+</template>
+
+<script setup lang="ts">
+import HeaderComponent from "../HeaderComponent.vue";
+import SidebarComponent from "../SidebarComponent.vue";
+import TypingTextComponent from "../../../modules/vue-components/typing-text/TypingText.vue";
+</script>
+
+<style>
+.typing-text {
+	display: block;
+	max-width: 50vw;
+	white-space: unset;
+	font-size: 24px;
+	line-height: 54px;
+	min-height: 5lh;
+	color: #e2e2e2;
+}
+
+.typing-text--animated > span {
+	animation: 0.5s color infinite;
+}
+
+@keyframes color {
+	50% {
+		color: #57bb9d;
+	}
+}
+</style>

--- a/src/docs/vue/typing-text/app.ts
+++ b/src/docs/vue/typing-text/app.ts
@@ -1,0 +1,4 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+
+createApp(App).mount("#app");

--- a/src/docs/vue/typing-text/index.html
+++ b/src/docs/vue/typing-text/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Typing Text Component</title>
+  <script defer src="./index.js"></script>
+  <script defer src="./typing-text/index.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>

--- a/src/modules/interfaces/component/typing-text/types.lit.ts
+++ b/src/modules/interfaces/component/typing-text/types.lit.ts
@@ -1,0 +1,5 @@
+import { TypingTextConfiguration } from "./types";
+
+export interface TypingTextLitConfiguration extends TypingTextConfiguration {
+    eachLetterAsSpan: boolean;
+}

--- a/src/modules/interfaces/component/typing-text/types.ts
+++ b/src/modules/interfaces/component/typing-text/types.ts
@@ -1,0 +1,5 @@
+import { ModifyingTextConfiguration } from "../../generic/selfModifyingText/selfModifyingText";
+
+export interface TypingTextConfiguration extends ModifyingTextConfiguration {
+    unTypingSpeed?: number;
+}

--- a/src/modules/vue-components/typing-text/TypingText.vue
+++ b/src/modules/vue-components/typing-text/TypingText.vue
@@ -1,0 +1,60 @@
+<template>
+	<pre>
+        <span v-for="letter in settings.currentTextValue.value" v-text="letter.letter" :class="letter.classes.join('')"></span>
+    </pre>
+</template>
+
+<script setup lang="ts">
+import { onUnmounted, ref } from "vue";
+import { TypingTextConfiguration } from "../../interfaces/component/typing-text/types";
+import { useSelfModifyingText } from "../../interfaces/generic/selfModifyingText/selfModifyingText.vue";
+
+const props = withDefaults(defineProps<TypingTextConfiguration>(), {
+	repetitions: 1,
+	interval: 4500,
+	typingSpeed: 35
+});
+const settings = useSelfModifyingText({
+	strings: props.strings,
+	repetitions: props.repetitions,
+	interval: props.interval,
+	typingSpeed: props.typingSpeed,
+	triggerTextAnimation
+});
+
+const timeout = ref<number | undefined>();
+
+async function triggerTextAnimation(fromText: string, toText: string) {
+	const fromArray = fromText.split("").map((letter) => ({ letter, classes: [] }));
+	const toArray = toText.split("").map((letter) => ({ letter, classes: [] }));
+
+	for (let i = 1; i < fromText.length + 1; i++) {
+		await new Promise<void>(
+			(resolve) =>
+				(timeout.value = window.setTimeout(() => {
+					settings.currentTextValue.value = fromArray.slice(0, -i);
+					resolve();
+				}, props.unTypingSpeed ?? props.typingSpeed))
+		);
+	}
+
+	for (let i = 1; i < toText.length + 1; i++) {
+		await new Promise<void>(
+			(resolve) =>
+				(timeout.value = window.setTimeout(() => {
+					settings.currentTextValue.value = toArray.slice(0, i);
+					resolve();
+				}, props.unTypingSpeed ?? props.typingSpeed))
+		);
+	}
+
+	setTimeout(() => {
+		clearTimeout(timeout.value);
+		settings.onInterval();
+	}, props.interval);
+}
+
+onUnmounted(() => {
+	clearTimeout(timeout.value);
+});
+</script>

--- a/src/modules/web-components/typing-text/typingText.ts
+++ b/src/modules/web-components/typing-text/typingText.ts
@@ -1,4 +1,5 @@
 import { customElement, property } from "lit/decorators.js";
+import { TypingTextLitConfiguration } from "src/modules/interfaces/component/typing-text/types.lit";
 import { SelfModifyingText } from "src/modules/interfaces/generic/selfModifyingText/selfModifyingText.lit";
 
 declare global {
@@ -8,7 +9,7 @@ declare global {
 }
 
 @customElement("typing-text-component")
-export class TypingTextComponent extends SelfModifyingText {
+export class TypingTextComponent extends SelfModifyingText implements TypingTextLitConfiguration {
 	@property({ type: Number })
 	interval = 4500;
 	@property({ type: Number })


### PR DESCRIPTION
## Description
This pull request implements the https://github.com/YuraVolk/Js-Library/issues/123 issue, as converting the toast component to Vue.

## Analysis
The Typing Text has been converted to Vue through the following steps:
1. There was found to be no need for the eachLetterAsSpan prop, and interfaces were isolated.
2. The rest of all logic with simplified rendering was created through a composable.

## Name of script
Typing Text.

## Browser Support
Issue occurred in 
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Opera

Possibly following:
- [x] IE
- [x] Safari
- [x] Safari for IOS
