### PR TITLE
Image Magnifier Feature

### DIFF
--- a/react/src/components/magnifier/Magnifier.module.css
+++ b/react/src/components/magnifier/Magnifier.module.css
@@ -1,0 +1,26 @@
+.magnifier {
+	position: relative;
+}
+
+.magnifier__image {
+	width: 100%;
+	height: 100%;
+}
+
+.magnifier__glass {
+	position: absolute;
+	top: -25px;
+	left: -25px;
+	width: 70px;
+	height: 70px;
+	border: 2px solid #222;
+	border-radius: 50%;
+	cursor: zoom-in;
+	background-repeat: no-repeat;
+}
+
+.magnifier-glass {
+	position: absolute;
+	border-radius: 50%;
+	background-repeat: no-repeat;
+}

--- a/react/src/components/magnifier/Magnifier.tsx
+++ b/react/src/components/magnifier/Magnifier.tsx
@@ -1,0 +1,83 @@
+import React, { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+import { MagnifierConfiguration, MagnifierExposedFunctions } from "../../interfaces/component/magnifier";
+import { ContextLinkedItems, ExposedContextFunctions } from "../../interfaces/hooks/useLinkedItem";
+import { assertNonUndefined } from "shared/utils/utils";
+import styles from "./Magnifier.module.css";
+
+const Magnifier = forwardRef<MagnifierExposedFunctions, MagnifierConfiguration>(
+	({ zoomScale = 2, ...props }: MagnifierConfiguration, ref) => {
+		const linkedItemsContext = useRef<ExposedContextFunctions | null>(null);
+		const image = useRef<HTMLDivElement>(null);
+
+		const moveMagnifier = useCallback((x: number, y: number) => {
+			if (!image.current) return;
+			const glass = linkedItemsContext.current?.getState()?.["magnifier-glass"];
+			assertNonUndefined(glass);
+			const element = glass.element.current;
+			assertNonUndefined(element);
+
+			const width = element.offsetWidth / 2,
+				height = element.offsetHeight / 2;
+			if (x > image.current.offsetWidth) {
+				x = image.current.offsetWidth;
+			} else if (x < 0) x = 0;
+			if (y > image.current.offsetHeight) {
+				y = image.current.offsetHeight;
+			} else if (y < 0) y = 0;
+
+			linkedItemsContext.current?.updateState({
+				"magnifier-glass": {
+					...glass,
+					styles: {
+						...glass.styles,
+						left: `${x - width}px`,
+						top: `${y - height}px`,
+						backgroundPosition: "-" + (x * zoomScale - width) + "px -" + (y * zoomScale - height) + "px"
+					}
+				}
+			});
+		}, [zoomScale]);
+
+		const onMouseMove = useCallback((event: React.MouseEvent) => {
+            if (!image.current) return;
+            event.preventDefault();
+            const rect = image.current.getBoundingClientRect();
+            moveMagnifier(event.pageX - rect.left - window.scrollX, event.pageY - rect.top - window.scrollY);
+        }, [moveMagnifier]);
+
+		const setup = useCallback(() => {
+			if (!image.current) return;
+			linkedItemsContext.current?.updateState((elements) => {
+				assertNonUndefined(image.current);
+				return {
+					"magnifier-glass": {
+						...elements["magnifier-glass"],
+						styles: {
+							backgroundImage: `url("${props.imageSource}")`,
+							backgroundSize: `${image.current.offsetWidth * zoomScale}px ${image.current.offsetHeight * zoomScale}px`
+						}
+					}
+				};
+			});
+		}, [props.imageSource, zoomScale]);
+
+		useImperativeHandle(ref, () => ({
+			onMouseMove(event) {
+				onMouseMove(event);
+			}
+		}));
+
+		return (
+			<ContextLinkedItems ref={linkedItemsContext} innerChildren={props.glassChildren} onAllElementsLoaded={setup}>
+				<div className={`${styles.magnifier} ${props.className ?? ""}`}>
+					<div className={styles.magnifier__image} onMouseMove={onMouseMove} ref={image}>
+						{props.imageChildren}
+					</div>
+					{props.glassChildren}
+				</div>
+			</ContextLinkedItems>
+		);
+	}
+);
+
+export { Magnifier };

--- a/react/src/components/magnifier/MagnifierGlass.tsx
+++ b/react/src/components/magnifier/MagnifierGlass.tsx
@@ -1,0 +1,25 @@
+import React, { useRef } from "react";
+import { useLinkedItem } from "../../../src/interfaces/hooks/useLinkedItem";
+import styles from "./Magnifier.module.css";
+import { MagnifierGlassProps } from "../../interfaces/component/magnifier";
+
+export const MagnifierGlass = (props: MagnifierGlassProps) => {
+	const item = useRef<HTMLDivElement>(null);
+	const styleObject = useLinkedItem(() => "magnifier-glass", item);
+
+	return (
+		<div
+			ref={item}
+			style={styleObject}
+			className={`${styles["magnifier-glass"]} ${props.className ?? ""}`}
+			onPointerMove={(e) => {
+				props.onGlassMove(e);
+			}}
+			onMouseMove={(e) => {
+				props.onGlassMove(e);
+			}}
+		>
+			{props.children}
+		</div>
+	);
+};

--- a/react/src/docs/react/magnifier/App.tsx
+++ b/react/src/docs/react/magnifier/App.tsx
@@ -1,0 +1,22 @@
+import React, { Suspense } from "react";
+import { createRoot } from "react-dom/client";
+import "../../../components/reactEntry";
+import "../../../global.css";
+const Page = React.lazy(() => import("./Page"));
+const Header = React.lazy(() => import("../Header"));
+const Sidebar = React.lazy(() => import("../Sidebar"));
+
+const root = createRoot(document.getElementById("app") ?? document.documentElement);
+root.render(
+	<React.StrictMode>
+        <Suspense>
+            <Header />
+        </Suspense>
+        <Suspense>
+            <Sidebar activeLink="Magnifier" />
+        </Suspense>
+		<Suspense>
+			<Page />
+		</Suspense>
+	</React.StrictMode>
+);

--- a/react/src/docs/react/magnifier/Page.module.css
+++ b/react/src/docs/react/magnifier/Page.module.css
@@ -1,0 +1,14 @@
+.magnifier {
+	border: 3px solid #333333;
+	width: 370px;
+	height: 220px;
+}
+
+.magnifier-glass {
+	top: -25px;
+	left: -25px;
+	width: 70px;
+	height: 70px;
+	border: 2px solid #222;
+	cursor: zoom-in;
+}

--- a/react/src/docs/react/magnifier/Page.tsx
+++ b/react/src/docs/react/magnifier/Page.tsx
@@ -1,0 +1,63 @@
+import React, { useRef } from "react";
+import image from "../../../../../assets/img/slide0.png";
+import { Magnifier } from "../../../components/magnifier/Magnifier";
+import styles from "./Page.module.css";
+import { MagnifierExposedFunctions } from "../../../interfaces/component/magnifier";
+import { MagnifierGlass } from "../../../components/magnifier/MagnifierGlass";
+
+const Page = () => {
+	const magnifier = useRef<MagnifierExposedFunctions>(null);
+
+	return (
+		<main className="main">
+			<h1 className="heading">Magnifier</h1>
+			<p>
+				The image magnifier component is a component that allows users to create an image magnifier effect on their web pages. The main
+				configuration is supplied automatically if you're using the correct configuration settings. This component is customizable to the
+				point you can control the magnifier glass programmatically without any issues and give any custom styles without any issues, with
+				all styling being available through CSS. In order to understand how to customize the component, you need to define two templates for
+				two slots: imageChildren prop that contains an image or any content you'd like to zoom, and glassChildren prop that contains
+				imported image magnifier glass component. Then, in order to ensure correct behavior you need to pass a callback and make a call to
+				image magnifier's component onMouseMove, you would need to persist the reference to magnifier through a React ref, which does expose
+				onMouseMove through an imperative handle. After this is set up, you'd need to setup the props for the image magnifier component:
+			</p>
+			<ul>
+				<li>zoomScale: A number that defines the scale of the magnified image. The default value is 2.</li>
+				<li>
+					imageSource: A string that defines the image URL for the magnifier, a required value for the setup to work correctly. You may give
+					this a different value from original image, i.e. image increased in quality.
+				</li>
+			</ul>
+			<p>Here is an example of correctly set up component:</p>
+			<Magnifier
+				className={styles.magnifier}
+				ref={magnifier}
+				imageSource={image}
+				imageChildren={<img src={image} alt="Example Image" />}
+				glassChildren={
+					<MagnifierGlass
+						className={styles["magnifier-glass"]}
+						onGlassMove={(e) => {
+							magnifier.current?.onMouseMove(e);
+						}}
+					/>
+				}
+			/>
+			<p>
+				After this default configuration, you're able to fully customize the magnifier glass mouse coordinates, shifts, and you are able to
+				give any CSS styles to the components. You should use fallthrough attributes on the image magnifier and image magnifier glass
+				components to achieve full styling control.
+			</p>
+			<p>
+				Next, you may see a very similar implementation that is called Zooming Image, with a lot of aspects being shared with this
+				implementation. However, there are important algorithmic differences between the two: this implementation is overall less robust and
+				works better when magnifying glass does not appear when not hovered. The other implementation provides a fallback effect that shows
+				an empty background when near to edge or moving from edge, while this implementation may not give such accurate results for edges.
+				This implementation on the other hand is much better for non-rectangular glass shapes, and is overall a perfect implementation for
+				statically visible non-rectangular glass.
+			</p>
+		</main>
+	);
+};
+
+export default Page;

--- a/react/src/docs/react/magnifier/index.html
+++ b/react/src/docs/react/magnifier/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Magnifier Component</title>
+  <script defer src="./index.js"></script>
+  <script defer src="./magnifier/index.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>

--- a/react/src/interfaces/component/magnifier.ts
+++ b/react/src/interfaces/component/magnifier.ts
@@ -1,0 +1,17 @@
+import { GenericReactComponentProps } from "../generic/classNameFallthrough";
+import { MagnifierConfiguration as SharedMagnifierConfiguration } from "shared/component/magnifier";
+import React, { ReactNode } from "react";
+
+export interface MagnifierGlassProps extends GenericReactComponentProps {
+    children?: ReactNode;
+    onGlassMove(event: React.MouseEvent<HTMLDivElement>): void;
+}
+
+export interface MagnifierConfiguration extends SharedMagnifierConfiguration, GenericReactComponentProps {
+    imageChildren: ReactNode;
+    glassChildren: ReactNode;
+}
+
+export interface MagnifierExposedFunctions {
+    onMouseMove(event: React.MouseEvent<HTMLElement>): void;
+}

--- a/react/src/interfaces/hooks/useLinkedItem.tsx
+++ b/react/src/interfaces/hooks/useLinkedItem.tsx
@@ -1,5 +1,6 @@
 import React, {
 	CSSProperties,
+	Children,
 	MutableRefObject,
 	ReactNode,
 	createContext,
@@ -71,8 +72,7 @@ const ContextLinkedItems = forwardRef<ExposedContextFunctions, ExposedContextPro
 	);
 
 	useEffect(() => {
-		if (wasSetupPerformed.current || !Array.isArray(props.innerChildren)) return;
-		if (Object.keys(elements).length === props.innerChildren.length) {
+		if (!wasSetupPerformed.current && Object.keys(elements).length === Children.toArray(props.innerChildren).length) {
 			wasSetupPerformed.current = true;
 			props.onAllElementsLoaded?.();
 		}

--- a/shared/component/magnifier.ts
+++ b/shared/component/magnifier.ts
@@ -1,0 +1,4 @@
+export interface MagnifierConfiguration {
+	imageSource: string;
+	zoomScale?: number;
+}

--- a/vue/src/components/magnifier/Magnifier.vue
+++ b/vue/src/components/magnifier/Magnifier.vue
@@ -10,11 +10,7 @@
 <script setup lang="ts">
 import { useInjectedLinkedItems } from "../../interfaces/hooks/useLinkedItem";
 import { onMounted, ref } from "vue";
-
-interface MagnifierConfiguration {
-  imageSource: string;
-  zoomScale?: number;
-}
+import { MagnifierConfiguration } from "shared/component/magnifier";
 
 const props = withDefaults(defineProps<MagnifierConfiguration>(), {
   zoomScale: 2


### PR DESCRIPTION
## Description
This pull request implements the magnifier component in React.

## Analysis
The magnifier component has been converted to React through the following steps:
1. The base logic of obtaining a component and interacting with linkedItemsContext was set up.
2. An imperative handle was exposed in order to ensure correct work of magnifier onMouseMove.
3. A bug was found due to the fluidness of React's children and JSX element structure, so Children.toArray utility was used in order to manage the state in useLinkedItem.

## Name of script
Magnifier Component.

## Browser Support
Issue occurred in 
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Opera

Possibly following:
- [x] IE
- [x] Safari
- [x] Safari for IOS
