### PR TITLE
React one page scroll feature

### DIFF
--- a/lit/src/components/ciphering-text/cipheringText.ts
+++ b/lit/src/components/ciphering-text/cipheringText.ts
@@ -1,6 +1,6 @@
 import { customElement, property } from "lit/decorators.js";
 import { CipheringTextConfiguration } from "shared/component/cipheringText";
-import { SelfModifyingText } from "../../interfaces/generic/selfModifyingText";
+import { SelfModifyingText, SplitTextParams, TriggerTextParams } from "../../interfaces/generic/selfModifyingText";
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -22,8 +22,8 @@ export class CipheringTextComponent extends SelfModifyingText implements Cipheri
   } })
   characters: string[] = ['!', '"', '#', '$', '%', '*', '0', '1', ':', ';', '?', '@', '[', ']', '\\', '~', "'", '/', '{', '}', '|', '&', '(', ')', '-', '<', '>'];
 
-  splitText(newString?: string) {
-    super.splitTextAlgorithm(newString);
+  splitText({ toText }: SplitTextParams) {
+    super.splitTextAlgorithm(toText);
   }
 
   protected cipherLetter(properties: { element: Element, newLetter: string, delayed: boolean, i: number }) {
@@ -51,10 +51,10 @@ export class CipheringTextComponent extends SelfModifyingText implements Cipheri
     return changeNumber * speed + speed;
   }
 
-  triggerTextAnimation(fromText: string, toText: string) {
+  triggerTextAnimation({ context, toText, fromText }: TriggerTextParams) {
     const newElements = Array.from(this.querySelectorAll('pre'));
     for (const element of newElements) element.textContent = fromText;
-    this.splitText(toText);
+    this.splitText({ context, toText });
 
     const speeds: number[] = [];
     for (const element of newElements) {
@@ -65,9 +65,7 @@ export class CipheringTextComponent extends SelfModifyingText implements Cipheri
       });
     }
     setTimeout(() => { 
-      this.onInterval().catch((e) => {
-        console.trace(e);
-      }); 
+      context.onInterval();
     }, Math.max(...speeds) + this.interval);
   }
 }

--- a/lit/src/components/rebuilding-text/rebuildingText.ts
+++ b/lit/src/components/rebuilding-text/rebuildingText.ts
@@ -1,5 +1,5 @@
 import { customElement, property } from "lit/decorators.js";
-import { SelfModifyingText } from "../../interfaces/generic/selfModifyingText";
+import { SelfModifyingText, TriggerTextParams } from "../../interfaces/generic/selfModifyingText";
 const RebuildingTextModule = import("shared/component/rebuildingText");
 
 declare global {
@@ -15,7 +15,7 @@ export class RebuildingTextComponent extends SelfModifyingText {
 	@property({ type: Number })
 	typingSpeed = 75;
 
-	async triggerTextAnimation(fromText: string, toText: string) {
+	async triggerTextAnimation({ context, fromText, toText }: TriggerTextParams) {
 		const { createRebuildingTextSteps } = await RebuildingTextModule;
 		const steps = createRebuildingTextSteps(fromText, toText);
 
@@ -26,9 +26,7 @@ export class RebuildingTextComponent extends SelfModifyingText {
 					if (i !== steps.length - 1) continue;
 
 					setTimeout(() => {
-						this.onInterval().catch((e) => {
-							console.trace(e);
-						});
+						context.onInterval();
 					}, this.interval);
 				}
 			}, this.typingSpeed * i);

--- a/lit/src/components/typing-text/typingText.ts
+++ b/lit/src/components/typing-text/typingText.ts
@@ -1,6 +1,6 @@
 import { customElement, property } from "lit/decorators.js";
 import { TypingTextLitConfiguration } from "../../interfaces/component/typingText";
-import { SelfModifyingText } from "../../interfaces/generic/selfModifyingText";
+import { SelfModifyingText, SplitTextParams, TriggerTextParams } from "../../interfaces/generic/selfModifyingText";
 
 declare global {
 	interface HTMLElementTagNameMap {
@@ -19,11 +19,11 @@ export class TypingTextComponent extends SelfModifyingText implements TypingText
 	@property({ type: Boolean })
 	eachLetterAsSpan = false;
 
-	splitText(newString?: string) {
-        if (this.eachLetterAsSpan) super.splitTextAlgorithm(newString);
+	splitText({ toText }: SplitTextParams) {
+        if (this.eachLetterAsSpan) super.splitTextAlgorithm(toText);
 	}
 
-	async triggerTextAnimation(fromText: string, toText: string) {
+	async triggerTextAnimation({ context, fromText, toText }: TriggerTextParams) {
 		const elements = this._elements;
 		for (let i = 1; i < fromText.length + 1; i++) {
 			await new Promise<void>((resolve) =>
@@ -52,9 +52,7 @@ export class TypingTextComponent extends SelfModifyingText implements TypingText
 		}
 
 		setTimeout(() => { 
-			this.onInterval().catch((e) => {
-				console.log(e);
-			});
+			context.onInterval();
 		}, this.interval);
 	}
 }

--- a/react/src/components/one-page-scroll/OnePageScroll.module.css
+++ b/react/src/components/one-page-scroll/OnePageScroll.module.css
@@ -1,0 +1,23 @@
+.wrap {
+	width: 100%;
+	height: 100%;
+	min-height: 100%;
+	max-height: 100%;
+	overflow-x: hidden;
+	overflow-y: scroll;
+}
+
+.wrap--horizontal {
+	display: flex;
+	overflow-x: scroll;
+	overflow-y: hidden;
+}
+
+.wrap--no-scrollbar {
+	overflow: hidden;
+}
+
+.one-page-scroll-item {
+    flex: 1 0 0;
+    box-sizing: border-box;
+}

--- a/react/src/components/one-page-scroll/OnePageScroll.tsx
+++ b/react/src/components/one-page-scroll/OnePageScroll.tsx
@@ -1,0 +1,108 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { ExposedContextFunctions, ContextLinkedItems } from "../../interfaces/hooks/useLinkedItem";
+import { easeInOutQuad } from "shared/component/onePageScroll";
+import { OnePageScrollConfiguration } from "../../interfaces/component/onePageScroll";
+import styles from "./OnePageScroll.module.css";
+import { CarouselDirection } from "shared/interfaces/carousel";
+
+export const OnePageScroll = ({
+	isHorizontal = false,
+	noScrollbar = true,
+	increment = 6,
+	duration = 500,
+	...props
+}: OnePageScrollConfiguration) => {
+	const linkedItemsContext = useRef<ExposedContextFunctions | null>(null);
+	const wrap = useRef<HTMLDivElement | null>(null);
+	const animationTimeout = useRef<{ timer?: number }>({ timer: undefined });
+	const selectedItem = useRef(0);
+	const isScrolling = useRef(false);
+
+	const smoothScrollTo = useCallback((to: number) => {
+		if (!wrap.current) return;
+		isScrolling.current = true;
+		const property = isHorizontal ? "scrollLeft" : "scrollTop";
+		const start = wrap.current[property],
+			change = to - start;
+		let currentTime = 0;
+
+        const animateScroll = () => {
+            if (!wrap.current) return;
+            currentTime += increment;
+            const quad = easeInOutQuad(currentTime, start, change, duration);
+            if (quad > increment) {
+                wrap.current[property] = quad - increment / 2;
+            } else wrap.current[property] = quad;
+    
+            if (currentTime < duration) {
+                animationTimeout.current.timer = window.setTimeout(animateScroll, increment);
+            } else if (currentTime >= duration) {
+                wrap.current[property] = to;
+                isScrolling.current = false;
+            }
+        };
+        
+        animateScroll();    
+	}, [duration, increment, isHorizontal]);
+
+	const scrollSlide = useCallback(
+		(direction: CarouselDirection) => {
+			const element = Object.values(linkedItemsContext.current?.getState() ?? {})[selectedItem.current]?.element?.current;
+			if (isScrolling.current || !element) return;
+			selectedItem.current += direction;
+
+			smoothScrollTo(element[isHorizontal ? "offsetWidth" : "offsetHeight"] * selectedItem.current);
+		},
+		[isHorizontal, smoothScrollTo]
+	);
+
+	const onWheel = useCallback(
+		(event: React.WheelEvent<HTMLDivElement>) => {
+			const elements = linkedItemsContext.current?.getState();
+			if (!elements) return;
+			const elementsLength = Object.keys(elements).length;
+			const firstElement = Object.values(elements)[0].element.current;
+			if (!firstElement) return;
+
+			if (event.deltaY > 0) {
+				if (selectedItem.current >= elementsLength - 1) {
+					if (isScrolling.current) return;
+					selectedItem.current = 0;
+					smoothScrollTo(0);
+				} else scrollSlide(CarouselDirection.FORWARDS);
+			} else {
+				if (selectedItem.current === 0) {
+					if (isScrolling.current || !wrap.current) return;
+					selectedItem.current = elementsLength - 1;
+					smoothScrollTo(
+						(isHorizontal ? wrap.current.scrollWidth : wrap.current.scrollHeight) -
+							(isHorizontal ? firstElement.offsetWidth : firstElement.offsetHeight)
+					);
+				} else scrollSlide(CarouselDirection.BACKWARDS);
+			}
+		},
+		[isHorizontal, scrollSlide, smoothScrollTo]
+	);
+
+	useEffect(() => {
+		const animationTimeoutObject = animationTimeout.current;
+
+		return () => {
+			window.clearTimeout(animationTimeoutObject.timer);
+		};
+	}, []);
+
+	return (
+		<ContextLinkedItems ref={linkedItemsContext} innerChildren={props.children}>
+			<article className={props.className}>
+				<div
+					ref={wrap}
+					onWheel={onWheel}
+					className={`${styles.wrap} ${isHorizontal ? styles["wrap--horizontal"] : ""} ${noScrollbar ? styles["wrap--no-scrollbar"] : ""}`}
+				>
+					{props.children}
+				</div>
+			</article>
+		</ContextLinkedItems>
+	);
+};

--- a/react/src/components/one-page-scroll/OnePageScrollItem.tsx
+++ b/react/src/components/one-page-scroll/OnePageScrollItem.tsx
@@ -1,0 +1,15 @@
+import React, { useRef } from "react";
+import { useLinkedItem } from "../../../src/interfaces/hooks/useLinkedItem";
+import { uid } from "shared/utils/utils";
+import { WithChildren } from "../../utils/utils";
+import styles from "./OnePageScroll.module.css";
+import { GenericReactComponentProps } from "../../interfaces/generic/classNameFallthrough";
+
+export const OnePageScrollItem = (props: WithChildren<object> & GenericReactComponentProps) => {
+    const item = useRef<HTMLDivElement | null>(null);
+    const styleObject = useLinkedItem(uid, item);
+
+    return <div ref={item} className={`${styles["one-page-scroll-item"]} ${props.className ?? ""}`} style={styleObject}>
+        {props.children}
+    </div>
+};

--- a/react/src/docs/react/one-page-scroll/App.tsx
+++ b/react/src/docs/react/one-page-scroll/App.tsx
@@ -1,0 +1,22 @@
+import React, { Suspense } from "react";
+import { createRoot } from "react-dom/client";
+import "../../../components/reactEntry";
+import "../../../global.css";
+const Page = React.lazy(() => import("./Page"));
+const Header = React.lazy(() => import("../Header"));
+const Sidebar = React.lazy(() => import("../Sidebar"));
+
+const root = createRoot(document.getElementById("app") ?? document.documentElement);
+root.render(
+	<React.StrictMode>
+        <Suspense>
+            <Header />
+        </Suspense>
+        <Suspense>
+            <Sidebar activeLink="One Page Scroll" />
+        </Suspense>
+		<Suspense>
+			<Page />
+		</Suspense>
+	</React.StrictMode>
+);

--- a/react/src/docs/react/one-page-scroll/Page.module.css
+++ b/react/src/docs/react/one-page-scroll/Page.module.css
@@ -1,0 +1,21 @@
+.one-page-scroll {
+	display: block;
+	width: 500px;
+	height: 500px;
+	border: 3px solid #333;
+}
+
+.one-page-scroll-slide {
+	min-width: 500px;
+	height: 500px;
+	box-sizing: border-box;
+	border: 3px solid #2390bb;
+	background-color: #62626253;
+	flex: 1 0 0;
+}
+
+.one-page-scroll-slide__heading {
+	margin: 0;
+	font-size: 32px;
+	line-height: 54px;
+}

--- a/react/src/docs/react/one-page-scroll/Page.tsx
+++ b/react/src/docs/react/one-page-scroll/Page.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { OnePageScroll } from "../../../components/one-page-scroll/OnePageScroll";
+import styles from "./Page.module.css";
+import { OnePageScrollItem } from "../../../components/one-page-scroll/OnePageScrollItem";
+
+const Page = () => {
+	return (
+		<main className="main">
+			<h1 className="heading">One Page Scroll</h1>
+			<p>
+				The one page scroll component provides a smooth scrolling experience for a single-page application. It allows users to navigate
+				through different sections of the page by scrolling vertically or horizontally. Its additional plus is that you do not need to
+				depend on custom animations, specific CSS styles. The internal formulas automatically adapt to most common scenarios.
+			</p>
+			<ul>
+				<li>
+					isHorizontal: A boolean property that determines whether the scrolling should be horizontal (true) or vertical (false). By
+					default, it is set to false.
+				</li>
+				<li>
+					duration: A number property that specifies the duration of the smooth scrolling animation in milliseconds. The default value is
+					500.
+				</li>
+				<li>
+					increment: A number property that determines the increment value for each step of the smooth scrolling animation. The default
+					value is 6.
+				</li>
+				<li>
+					noScrollbar: A boolean property that controls whether the scrollbars should be hidden (true) or visible (false). Enabled by
+					default.
+				</li>
+			</ul>
+			<OnePageScroll className={styles["one-page-scroll"]}>
+				<OnePageScrollItem className={styles["one-page-scroll-slide"]}>
+					<p className={styles["one-page-scroll-slide__heading"]}>First slide. Scroll down...</p>
+				</OnePageScrollItem>
+				<OnePageScrollItem className={styles["one-page-scroll-slide"]}>
+					<p className={styles["one-page-scroll-slide__heading"]}>Second slide</p>
+				</OnePageScrollItem>
+				<OnePageScrollItem className={styles["one-page-scroll-slide"]}>
+					<p className={styles["one-page-scroll-slide__heading"]}>Third slide.</p>
+				</OnePageScrollItem>
+				<OnePageScrollItem className={styles["one-page-scroll-slide"]}>
+					<p className={styles["one-page-scroll-slide__heading"]}>Fourth slide.</p>
+				</OnePageScrollItem>
+			</OnePageScroll>
+			<p>Here is an example of horizontal one-page scroll:</p>
+			<OnePageScroll className={styles["one-page-scroll"]} isHorizontal>
+				<OnePageScrollItem className={styles["one-page-scroll-slide"]}>
+					<p className={styles["one-page-scroll-slide__heading"]}>First slide. Scroll down...</p>
+				</OnePageScrollItem>
+				<OnePageScrollItem className={styles["one-page-scroll-slide"]}>
+					<p className={styles["one-page-scroll-slide__heading"]}>Second slide</p>
+				</OnePageScrollItem>
+				<OnePageScrollItem className={styles["one-page-scroll-slide"]}>
+					<p className={styles["one-page-scroll-slide__heading"]}>Third slide.</p>
+				</OnePageScrollItem>
+				<OnePageScrollItem className={styles["one-page-scroll-slide"]}>
+					<p className={styles["one-page-scroll-slide__heading"]}>Fourth slide.</p>
+				</OnePageScrollItem>
+			</OnePageScroll>
+			<p>
+				In order to get some default styling, it is highly recommended you use the local provided one page scroll item component along with
+				the one page scroll component in order to get the one page scroll work right away with minimum configuration.
+			</p>
+		</main>
+	);
+};
+
+export default Page;

--- a/react/src/docs/react/one-page-scroll/index.html
+++ b/react/src/docs/react/one-page-scroll/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>One Page Scroll Component</title>
+  <script defer src="./index.js"></script>
+  <script defer src="./one-page-scroll/index.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>

--- a/react/src/interfaces/component/onePageScroll.ts
+++ b/react/src/interfaces/component/onePageScroll.ts
@@ -1,0 +1,7 @@
+import { OnePageScrollConfiguration as RootConfiguration } from "shared/component/onePageScroll";
+import { GenericReactComponentProps } from "../generic/classNameFallthrough";
+import { ReactNode } from "react";
+
+export interface OnePageScrollConfiguration extends Partial<RootConfiguration>, GenericReactComponentProps {
+    children: ReactNode;
+}

--- a/react/src/interfaces/generic/selfModifyingText.ts
+++ b/react/src/interfaces/generic/selfModifyingText.ts
@@ -1,8 +1,0 @@
-import { LetterSettings, SelfModifyingTextInterface } from "shared/interfaces/selfModifyingText";
-
-export interface ReactModifyingTextFunctions {
-    interval: React.MutableRefObject<number | undefined>;
-    settings: SelfModifyingTextInterface;
-    currentTextValue: LetterSettings[];
-    setCurrentTextValue: React.Dispatch<LetterSettings[]>;
-}

--- a/shared/interfaces/selfModifyingText.ts
+++ b/shared/interfaces/selfModifyingText.ts
@@ -5,19 +5,34 @@ export interface ModifyingTextConfiguration {
 	typingSpeed?: number;
 }
 
-export interface SelfModifyingTextInterface extends Required<ModifyingTextConfiguration> {
-	splitText?(newString?: string): void | Promise<void>;
-	triggerTextAnimation(fromText: string, toText: string): void | Promise<void>;
+export interface ModifyingTextContext {
+	onInterval: () => void;
+}
+
+export type TriggerTextAnimationCallback<T extends ModifyingTextContext> = (parameters: {
+	context: T;
+	fromText: string;
+	toText: string;
+}) => void | Promise<void>;
+export type SplitTextCallback<T extends ModifyingTextContext> = (parameters: {
+	context: T;
+	toText?: string;
+	fromText?: string;
+}) => void | Promise<void>;
+
+export interface SelfModifyingTextInterface<T extends ModifyingTextContext> extends Required<ModifyingTextConfiguration> {
+	splitText?: SplitTextCallback<T>;
+	triggerTextAnimation: TriggerTextAnimationCallback<T>;
 }
 
 export interface LetterSettings {
-    letter: string;
-    classes: string[];
+	letter: string;
+	classes: string[];
 }
 
-export function* nextStringsGenerator(
+export function* nextStringsGenerator<T extends ModifyingTextContext>(
 	startingString: string,
-	options: SelfModifyingTextInterface
+	options: SelfModifyingTextInterface<T>
 ): Generator<[string, string], [string, string], [string, string]> {
 	const newStrings = [...options.strings];
 	let index = 1,
@@ -34,7 +49,7 @@ export function* nextStringsGenerator(
 }
 
 export const splitTextAlgorithm = (currentString: LetterSettings[], newString: string): LetterSettings[] => {
-    return [...currentString.map(({ letter }) => letter).filter(Boolean), 
-        ...newString.split("").slice(currentString.length).fill(" ")]
-        .map(letter => ({ letter, classes: [] }));
+	return [...currentString.map(({ letter }) => letter).filter(Boolean), ...newString.split("").slice(currentString.length).fill(" ")].map(
+		(letter) => ({ letter, classes: [] })
+	);
 };

--- a/vue/src/components/one-page-scroll/OnePageScroll.vue
+++ b/vue/src/components/one-page-scroll/OnePageScroll.vue
@@ -43,12 +43,13 @@ const smoothScrollTo = (to: number) => {
 		} else wrap.value[property] = quad;
 
 		if (currentTime < props.duration) {
-			setTimeout(animateScroll, props.increment);
+			animationTimeout.value = window.setTimeout(animateScroll, props.increment);
 		} else if (currentTime >= props.duration) {
 			wrap.value[property] = to;
 			isScrolling.value = false;
 		}
 	};
+
 	animateScroll();
 };
 

--- a/vue/src/components/rebuilding-text/RebuildingText.vue
+++ b/vue/src/components/rebuilding-text/RebuildingText.vue
@@ -6,23 +6,20 @@
 
 <script setup lang="ts">
 import { createRebuildingTextSteps } from "shared/component/rebuildingText";
-import { ModifyingTextConfiguration } from "shared/interfaces/selfModifyingText";
-import { useSelfModifyingText } from "../../interfaces/hooks/useSelfModifyingText";
+import { ModifyingTextConfiguration, TriggerTextAnimationCallback } from "shared/interfaces/selfModifyingText";
+import { ModifyingTextContext, useSelfModifyingText } from "../../interfaces/hooks/useSelfModifyingText";
 
-const props = defineProps<ModifyingTextConfiguration>();
-const settings = useSelfModifyingText({
-	strings: props.strings,
-	repetitions: props.repetitions ?? 1,
-	interval: props.interval ?? 2500,
-	typingSpeed: props.typingSpeed ?? 75,
-	triggerTextAnimation
+const props = withDefaults(defineProps<ModifyingTextConfiguration>(), {
+	repetitions: 1,
+	interval: 2500,
+	typingSpeed: 75
 });
 
-function triggerTextAnimation(fromText: string, toText: string) {
+const triggerTextAnimation: TriggerTextAnimationCallback<ModifyingTextContext> = ({ context, fromText, toText }) => {
 	const steps = createRebuildingTextSteps(fromText, toText);
 	for (let i = 0; i < steps.length; i++) {
 		setTimeout(() => {
-			settings.currentTextValue.value = steps[i]
+			context.currentTextValue.value = steps[i]
 				.filter<string>((s): s is string => Boolean(s))
 				.map((letter) => ({
 					letter,
@@ -31,10 +28,18 @@ function triggerTextAnimation(fromText: string, toText: string) {
 
 			if (i === steps.length - 1) {
 				setTimeout(() => {
-					settings.onInterval();
-				}, settings.settings.interval);
+					context.onInterval();
+				}, props.interval);
 			}
-		}, settings.settings.typingSpeed * i);
+		}, props.typingSpeed * i);
 	}
-}
+};
+
+const settings = useSelfModifyingText({
+	strings: props.strings,
+	repetitions: props.repetitions,
+	interval: props.interval,
+	typingSpeed: props.typingSpeed,
+	triggerTextAnimation
+});
 </script>

--- a/vue/src/interfaces/hooks/useSelfModifyingText.ts
+++ b/vue/src/interfaces/hooks/useSelfModifyingText.ts
@@ -1,32 +1,44 @@
-import { ref, onMounted, onUnmounted } from "vue";
+import { ref, onMounted, onUnmounted, computed } from "vue";
 import {
 	LetterSettings,
 	SelfModifyingTextInterface,
 	nextStringsGenerator,
-	splitTextAlgorithm as algorithm
+	splitTextAlgorithm as algorithm,
+	ModifyingTextContext as RootTextContext
 } from "shared/interfaces/selfModifyingText";
 
+export interface ModifyingTextContext extends RootTextContext {
+	currentTextValue: {
+		value: LetterSettings[];
+	};
+}
+
 export const splitTextAlgorithm = algorithm;
-export function useSelfModifyingText(settings: SelfModifyingTextInterface) {
+export function useSelfModifyingText(settings: SelfModifyingTextInterface<ModifyingTextContext>) {
 	const interval = ref<number | undefined>(undefined);
 	const generator = ref(nextStringsGenerator(settings.strings[0], settings));
 	const currentTextValue = ref<LetterSettings[]>(settings.strings[0].split("").map((letter) => ({ letter, classes: [] })));
 
-	const onInterval = () => {
+	const context = computed(() => ({
+		currentTextValue,
+		onInterval
+	}));
+
+	function onInterval() {
 		const { done, value } = generator.value.next();
 		if (done) {
 			window.clearTimeout(interval.value);
 			interval.value = undefined;
-		} else void settings.triggerTextAnimation(...value);
-	};
+		} else void settings.triggerTextAnimation({ context: context.value, fromText: value[0], toText: value[1] });
+	}
 
 	onMounted(() => {
-		settings.splitText?.();
+		settings.splitText?.({ context: context.value });
 		interval.value = window.setTimeout(() => {
 			onInterval();
 		}, settings.interval);
 	});
-    
+
 	onUnmounted(() => {
 		generator.value.return(["", ""]);
 		window.clearTimeout(settings.interval);


### PR DESCRIPTION
## Description
This pull request implements the One Page Scroll component in React.
In addition, this pull request improves the self-modifying text interfaces through a refactoring.

## Analysis
The One Page Scroll component has been implemented in React through the following steps:
1. The initial structure was created through JSX.
2. A decision was taken to not use any state and persist computations through refs.
3. Animation timeout solutions have been investigated and the best solution for cleaning it up was storing another object inside a ref to persist its reference.

The interfaces of self-modifying text have been refactored in the following steps:
1. An initial attempt to add context as a parameter has been undertaken, and successfully so in React: context was generic and must always contain onInterval.
2. React hook was converted via wrapping useMemo.
3. Vue and Lit were converted without using function hoisting at components, only at composable in Vue, but were left with unused properties.
4. The interface system was refactored to accept an object of parameters.
5. Vue has been successfully converted to parameter objects and default props.
6. Due to similarity of parameter objects an attempt to merge them via a common interface was made to no avail. At the end type aliases were made for both functions of splitText and triggerTextAlgorithm.
7. The Lit code has been converted to use context object, so that it could programmatically substituted.

## Name of script

- One Page Scroll Component.
- Ciphering Text Component.
- Rebuilding Text Component.
- Typing Text Component.

## Browser Support
Issue occurred in 
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Opera

Possibly following:
- [x] IE
- [x] Safari
- [x] Safari for IOS
