### PR TITLE
Implement perspective carousel in React

### DIFF
--- a/react/src/components/perspective-carousel/PerspectiveCarousel.module.css
+++ b/react/src/components/perspective-carousel/PerspectiveCarousel.module.css
@@ -1,0 +1,18 @@
+.wrap {
+	position: relative;
+}
+
+.images {
+	width: 80%;
+	padding: 0;
+	margin: 0;
+	list-style-type: none;
+}
+
+.carousel-controls {
+	position: absolute;
+	left: 40%;
+	transform: translateX(-50%);
+	bottom: -5%;
+	z-index: 99;
+}

--- a/react/src/components/perspective-carousel/PerspectiveCarousel.tsx
+++ b/react/src/components/perspective-carousel/PerspectiveCarousel.tsx
@@ -1,0 +1,399 @@
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { PerspectiveCarouselConfiguration } from "../../interfaces/component/perspectiveCarousel";
+import { PerspectiveCarouselItemState, resetInternalState } from "shared/component/perspectiveCarousel";
+import { ContextLinkedItems, ExposedContextFunctions, LinkedReactItem } from "../../interfaces/hooks/useLinkedItem";
+import carouselControlsStyles from "../../interfaces/generic/CarouselControls.module.css";
+import styles from "./PerspectiveCarousel.module.css";
+import { assertNonUndefined } from "shared/utils/utils";
+import { CarouselDirection } from "shared/interfaces/carousel";
+
+const getDataFromExposedFunctions = (contextObject: React.MutableRefObject<ExposedContextFunctions | null>) => {
+	const linkedItemsContextsState = contextObject.current?.getState();
+	const keys = Object.keys(linkedItemsContextsState ?? {});
+	const entries = Object.entries(linkedItemsContextsState ?? {});
+
+	return { keys, entries: [...entries].map(([k, v]): [string, LinkedReactItem] => [k, { ...v }]) };
+};
+
+export const enum PerspectiveCarouselState {
+	INITIALIZING,
+	AWAITING_LAYOUT_EFFECT,
+	FINISHED
+}
+
+export const PerspectiveCarousel = ({
+	imageSize = "300px",
+	margin = "250px auto",
+	startingItem: propsStartingItem = 1,
+	separation: propsSeparation = 175,
+	separationMultiplier = 0.6,
+	horizonOffset: propsHorizonOffset = 0,
+	horizonOffsetMultiplier = 1,
+	sizeMultiplier = 0.7,
+	opacityMultiplier = 0.87,
+	horizon: propsHorizon = 0,
+	flankingItems = 3,
+	isVertical: propsIsVertical = false,
+	forcedImageWidth = 0,
+	forcedImageHeight = 0,
+	animationLength = 300,
+	allowSwitchingOrientation = false,
+	movingToCenter,
+	movedToCenter,
+	movingFromCenter,
+	...props
+}: Partial<PerspectiveCarouselConfiguration>) => {
+	const imageStyles = useMemo(
+		() => ({
+			margin,
+			height: imageSize
+		}),
+		[imageSize, margin]
+	);
+
+	const timeouts = useRef<number[]>();
+	const [isInitializing, setInitializing] = useState(PerspectiveCarouselState.INITIALIZING);
+
+	const linkedItemsContext = useRef<ExposedContextFunctions | null>(null);
+	const state = useRef(resetInternalState<number>());
+	const elementsState = useRef<Record<string, Partial<PerspectiveCarouselItemState>>>({});
+	const parent = useRef<HTMLUListElement>(null);
+	const horizon = useRef(propsHorizon);
+	const startingItem = useRef(propsStartingItem);
+	const isVertical = useRef(propsIsVertical);
+
+	const forceImageDimensionsIfEnabled = useCallback(() => {
+		const { entries } = getDataFromExposedFunctions(linkedItemsContext);
+		for (const [, image] of entries) {
+			image.styles = { display: "none" };
+			if (!forcedImageWidth || !forcedImageHeight) continue;
+			image.styles = {
+				...image.styles,
+				width: `${forcedImageWidth}px`,
+				height: `${forcedImageHeight}px`
+			};
+		}
+
+		linkedItemsContext.current?.updateState(Object.fromEntries(entries));
+	}, [forcedImageHeight, forcedImageWidth]);
+
+	const initializeCarouselData = useCallback(() => {
+		const { keys } = getDataFromExposedFunctions(linkedItemsContext);
+		assertNonUndefined(parent.current);
+		const parentStyle = window.getComputedStyle(parent.current);
+		state.current.totalItems = keys.length;
+		state.current.containerDimensions = [parseInt(parentStyle.width, 10), parseInt(parentStyle.height, 10)];
+	}, []);
+
+	const setOriginalItemDimensions = useCallback(() => {
+		const { entries } = getDataFromExposedFunctions(linkedItemsContext);
+		for (const [key, { element }] of entries) {
+			if (!element.current) continue;
+
+			const state = elementsState.current[key];
+			if ((!state.originalWidth && !state.originalHeight) || forcedImageWidth > 0 || forcedImageHeight > 0) {
+				const initialDisplay = element.current.style.display;
+				element.current.style.display = "";
+				if (!state.originalWidth || forcedImageWidth > 0) state.originalWidth = element.current.clientWidth;
+				if (!state.originalHeight || forcedImageHeight > 0) state.originalHeight = element.current.clientHeight;
+				element.current.style.display = initialDisplay;
+			}
+		}
+	}, [forcedImageHeight, forcedImageWidth]);
+
+	const calculatePositionProperties = useCallback(() => {
+		let horizonOffset = propsHorizonOffset;
+		let separation = propsSeparation;
+		for (let i = 1; i <= flankingItems + 2; i++) {
+			if (i > 1) {
+				horizonOffset *= horizonOffsetMultiplier;
+				separation *= separationMultiplier;
+			}
+
+			const { distance, offset, opacity } = state.current.calculations[i - 1];
+			state.current.calculations[i] = {
+				distance: distance + separation,
+				offset: offset + horizonOffset,
+				opacity: opacity * opacityMultiplier
+			};
+		}
+
+		state.current.calculations[flankingItems + 1] = {
+			distance: 0,
+			offset: 0,
+			opacity: 0
+		};
+	}, [flankingItems, horizonOffsetMultiplier, opacityMultiplier, propsHorizonOffset, propsSeparation, separationMultiplier]);
+
+	const setupCarousel = useCallback(() => {
+		horizon.current ||= state.current.containerDimensions[Number(!isVertical.current)] / 2;
+		const { entries } = getDataFromExposedFunctions(linkedItemsContext);
+
+		for (const [key, item] of entries) {
+			const itemState = elementsState.current[key];
+			let left, top;
+			if (isVertical.current) {
+				left = horizon.current - Number(itemState.originalWidth) / 2;
+				top = state.current.containerDimensions[1] / 2 - Number(itemState.originalHeight) / 2;
+			} else {
+				left = state.current.containerDimensions[0] / 2 - Number(itemState.originalWidth) / 2;
+				top = horizon.current - Number(itemState.originalHeight) / 2;
+			}
+
+			item.styles = {
+				...item.styles,
+				left: `${left}px`,
+				top: `${top}px`,
+				visibility: "visible",
+				position: "absolute",
+				zIndex: 0,
+				opacity: 0,
+				display: ""
+			};
+		}
+
+		linkedItemsContext.current?.updateState(Object.fromEntries(entries));
+	}, [isVertical]);
+
+	const performCalculations = useCallback(
+		(elementIndex: number, newPosition: number) => {
+			const { keys } = getDataFromExposedFunctions(linkedItemsContext);
+			const itemState = elementsState.current[keys[elementIndex]];
+
+			const newDistanceFromCenter = Math.abs(newPosition);
+			const calculations =
+				newDistanceFromCenter < flankingItems + 1
+					? state.current.calculations[newDistanceFromCenter]
+					: state.current.calculations[flankingItems + 1];
+			const distanceFactor = sizeMultiplier ** newDistanceFromCenter;
+			const newWidth = distanceFactor * Number(itemState.originalWidth);
+			const newHeight = distanceFactor * Number(itemState.originalHeight);
+			const newDistance = newPosition < 0 ? -calculations.distance : calculations.distance;
+
+			const center = state.current.containerDimensions[Number(isVertical.current)] / 2;
+			let top: number, left: number;
+			if (isVertical.current) {
+				left = horizon.current - calculations.offset - newWidth / 2;
+				top = center + newDistance - newHeight / 2;
+			} else {
+				left = center + newDistance - newWidth / 2;
+				top = horizon.current - calculations.offset - newHeight / 2;
+			}
+
+			itemState.width = newWidth;
+			itemState.height = newHeight;
+			itemState.top = top;
+			itemState.left = left;
+			itemState.oldPosition ??= 0;
+			itemState.depth = flankingItems + 2 - newDistanceFromCenter;
+			itemState.opacity = newPosition ? calculations.opacity : 1;
+		},
+		[flankingItems, sizeMultiplier]
+	);
+
+	const { setupStarterRotation, rotateCarousel } = useMemo(() => {
+		const rotateCarousel = () => {
+			if (state.current.currentlyMoving) return;
+			state.current.currentlyMoving = true;
+			state.current.itemsAnimating = 0;
+			state.current.carouselRotationsLeft++;
+
+			getDataFromExposedFunctions(linkedItemsContext).keys.forEach((key, i) => {
+				const currentPosition = elementsState.current[key].currentPosition ?? NaN;
+				let newPosition = currentPosition + -Number(state.current.currentDirection);
+
+				if (Math.abs(newPosition) > state.current[newPosition > 0 ? "rightItemsCount" : "leftItemsCount"]) {
+					newPosition = -currentPosition;
+					if (state.current.totalItems % 2 === 0) newPosition++;
+				}
+
+				moveItem(i, newPosition);
+			});
+		};
+
+		const itemAnimationComplete = (elementIndex: number, newPosition: number) => {
+			const { keys } = getDataFromExposedFunctions(linkedItemsContext);
+			const itemState = elementsState.current[keys[elementIndex]];
+			state.current.itemsAnimating--;
+			itemState.currentPosition = newPosition;
+			if (newPosition === 0) state.current.currentCenterItem = elementIndex;
+			if (state.current.itemsAnimating) return;
+			state.current.currentlyMoving = false;
+
+			if (--state.current.carouselRotationsLeft <= 0) {
+				if (!state.current.performingSetup) {
+					movingToCenter?.();
+					movedToCenter?.();
+				} else state.current.performingSetup = false;
+			}
+		};
+
+		const moveItem = (elementIndex: number, newPosition: number) => {
+			linkedItemsContext.current?.updateState((linkedItemsContextsState) => {
+				const keys = Object.keys(linkedItemsContextsState);
+				const entries = Object.entries(linkedItemsContextsState).map(([k, v]): [string, LinkedReactItem] => [k, { ...v }]);
+
+				const item = entries[elementIndex][1];
+				const itemState = elementsState.current[keys[elementIndex]];
+
+				const assignToItem = () => {
+					item.styles = {
+						...item.styles,
+						left: `${itemState.left}px`,
+						width: `${itemState.width}px`,
+						height: `${itemState.height}px`,
+						top: `${itemState.top}px`,
+						opacity: String(itemState.opacity)
+					};
+				};
+
+				if (Math.abs(newPosition) <= flankingItems + 1) {
+					performCalculations(elementIndex, newPosition);
+					state.current.itemsAnimating++;
+
+					item.styles = {
+						...item.styles,
+						zIndex: itemState.depth ?? ""
+					};
+					assignToItem();
+
+					const timeout = window.setTimeout(() => {
+						itemAnimationComplete(elementIndex, newPosition);
+					}, animationLength);
+					timeouts.current?.push(timeout);
+				} else {
+					itemState.currentPosition = newPosition;
+					if (!itemState.oldPosition) {
+						performCalculations(elementIndex, newPosition);
+						assignToItem();
+					}
+				}
+
+				return Object.fromEntries(entries);
+			});
+		};
+
+		const setupStarterRotation = () => {
+			const { entries } = getDataFromExposedFunctions(linkedItemsContext);
+			startingItem.current ||= Math.round(state.current.totalItems / 2);
+			state.current.rightItemsCount = Math.ceil((state.current.totalItems - 1) / 2);
+			state.current.leftItemsCount = Math.floor((state.current.totalItems - 1) / 2);
+			state.current.carouselRotationsLeft = 1;
+
+			let itemIndex = startingItem.current - 1;
+			const moveToIndex = (pos: number) => {
+				entries[itemIndex][1].styles = {
+					...entries[itemIndex][1].styles,
+					opacity: 1
+				};
+
+				moveItem(itemIndex, pos);
+			};
+			moveToIndex(0);
+
+			for (let pos = 1; pos <= state.current.rightItemsCount; pos++) {
+				itemIndex < state.current.totalItems - 1 ? itemIndex++ : (itemIndex = 0);
+				moveToIndex(pos);
+			}
+			itemIndex = startingItem.current - 1;
+			for (let pos = -1; pos >= -state.current.leftItemsCount; pos--) {
+				itemIndex > 0 ? itemIndex-- : (itemIndex = state.current.totalItems - 1);
+				moveToIndex(pos);
+			}
+		};
+
+		return { setupStarterRotation, rotateCarousel };
+	}, [animationLength, flankingItems, movedToCenter, movingToCenter, performCalculations]);
+
+	const moveOnce = useCallback(
+		(direction: CarouselDirection) => {
+			if (state.current.currentlyMoving) return;
+			if (direction === CarouselDirection.BACKWARDS && state.current.currentCenterItem !== undefined) {
+				movingFromCenter?.(state.current.currentCenterItem - 1 < 0 ? undefined : state.current.currentCenterItem - 1);
+			} else if (direction === CarouselDirection.FORWARDS && state.current.currentCenterItem !== undefined) {
+				movingFromCenter?.(
+					state.current.currentCenterItem + 1 > state.current.totalItems ? undefined : state.current.currentCenterItem + 1
+				);
+			} else movingFromCenter?.(state.current.currentCenterItem);
+
+			state.current.currentDirection = direction;
+		},
+		[movingFromCenter]
+	);
+
+	const previousItem = useCallback(() => {
+		moveOnce(CarouselDirection.BACKWARDS);
+		rotateCarousel();
+	}, [moveOnce, rotateCarousel]);
+
+	const switchOrientation = useCallback(() => {
+		if (!allowSwitchingOrientation) return;
+		isVertical.current = !isVertical.current;
+		rotateCarousel();
+	}, [allowSwitchingOrientation, rotateCarousel]);
+
+	const nextItem = useCallback(() => {
+		moveOnce(CarouselDirection.FORWARDS);
+		rotateCarousel();
+	}, [moveOnce, rotateCarousel]);
+
+	const initCarousel = useCallback(() => {
+		if (!parent.current) return;
+		setInitializing(PerspectiveCarouselState.INITIALIZING);
+		state.current = resetInternalState();
+
+		const { keys } = getDataFromExposedFunctions(linkedItemsContext);
+		for (const key of keys) {
+			if (typeof elementsState.current[key] === "undefined") elementsState.current[key] = {};
+		}
+
+		initializeCarouselData();
+		forceImageDimensionsIfEnabled();
+		setInitializing(PerspectiveCarouselState.AWAITING_LAYOUT_EFFECT);
+	}, [forceImageDimensionsIfEnabled, initializeCarouselData]);
+
+	useLayoutEffect(() => {
+		if (isInitializing !== PerspectiveCarouselState.AWAITING_LAYOUT_EFFECT) return;
+		setOriginalItemDimensions();
+		calculatePositionProperties();
+		setupCarousel();
+		setupStarterRotation();
+		setInitializing(PerspectiveCarouselState.FINISHED);
+
+		const timeoutsRef = timeouts.current;
+		return () => {
+			const isInitializingCurrent: number = isInitializing;
+			const awaitingLayoutEffect: number = PerspectiveCarouselState.AWAITING_LAYOUT_EFFECT;
+			if (isInitializingCurrent === awaitingLayoutEffect) return;
+			timeoutsRef?.forEach(window.clearTimeout);
+			timeouts.current = [];
+		};
+	}, [calculatePositionProperties, isInitializing, setOriginalItemDimensions, setupCarousel, setupStarterRotation]);
+
+	useEffect(() => {
+		window.addEventListener("resize", initCarousel);
+
+		return () => {
+			window.removeEventListener("resize", initCarousel);
+		};
+	}, [initCarousel]);
+
+	return (
+		<ContextLinkedItems ref={linkedItemsContext} innerChildren={props.children} onAllElementsLoaded={initCarousel}>
+			<div className={styles.wrap}>
+				<ul className={styles.images} style={imageStyles} ref={parent}>
+					{props.children}
+				</ul>
+				<div className={`${styles["carousel-controls"]} ${carouselControlsStyles["carousel-controls"]}`}>
+					<button className={carouselControlsStyles["carousel-controls__previous-button"]} onClick={previousItem}></button>
+					{allowSwitchingOrientation && (
+						<button className={carouselControlsStyles["carousel-controls__perspective-button"]} onClick={switchOrientation}>
+							Switch
+						</button>
+					)}
+					<button className={carouselControlsStyles["carousel-controls__next-button"]} onClick={nextItem}></button>
+				</div>
+			</div>
+		</ContextLinkedItems>
+	);
+};

--- a/react/src/docs/react/perspective-carousel/App.tsx
+++ b/react/src/docs/react/perspective-carousel/App.tsx
@@ -1,0 +1,22 @@
+import React, { Suspense } from "react";
+import { createRoot } from "react-dom/client";
+import "../../../components/reactEntry";
+import "../../../global.css";
+const Page = React.lazy(() => import("./Page"));
+const Header = React.lazy(() => import("../Header"));
+const Sidebar = React.lazy(() => import("../Sidebar"));
+
+const root = createRoot(document.getElementById("app") ?? document.documentElement);
+root.render(
+	<React.StrictMode>
+        <Suspense>
+            <Header />
+        </Suspense>
+        <Suspense>
+            <Sidebar activeLink="Perspective Carousel" />
+        </Suspense>
+		<Suspense>
+			<Page />
+		</Suspense>
+	</React.StrictMode>
+);

--- a/react/src/docs/react/perspective-carousel/Page.module.css
+++ b/react/src/docs/react/perspective-carousel/Page.module.css
@@ -1,0 +1,10 @@
+.carousel-item {
+	width: 370px;
+	height: 220px;
+    transition: 0.3s linear left, 0.3s linear width, 0.3s linear height, 0.3s linear top, 0.3s linear opacity;
+}
+
+.img {
+    width: 100%;
+    height: 100%;
+}

--- a/react/src/docs/react/perspective-carousel/Page.tsx
+++ b/react/src/docs/react/perspective-carousel/Page.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import styles from "./Page.module.css";
+import { PerspectiveCarousel } from "../../../components/perspective-carousel/PerspectiveCarousel";
+import { CarouselItem } from "../../../interfaces/generic/CarouselItem";
+import image1 from "../../../../../assets/img/slide0.png";
+import image2 from "../../../../../assets/img/slide1.png";
+import image3 from "../../../../../assets/img/slide2.png";
+import image4 from "../../../../../assets/img/slide3.png";
+import image5 from "../../../../../assets/img/slide4.png";
+import image6 from "../../../../../assets/img/slide5.png";
+
+const Page = () => {
+	return (
+		<main className="main">
+			<h1 className="heading">Perspective Carousel</h1>
+			<p>
+				This component creates a representation of a carousel with lined up images, showing multiple images at the same time if configured.
+				This carousel creates a visually compelling effect, with central image being fully visible and flanking images surrounding the
+				central images, shifting and flowing as needed when restructuring or rotating the carousel. This component has numerous
+			</p>
+			<ul>
+				<li>
+					imageSize, a string that sets the height for the carousel images container, effectively sets carousel horizontal orientation
+					width. Defaults to "300px".
+				</li>
+				<li>
+					margin, a string that sets the margin applied to the carousel images container, needed to correctly handle the switch between
+					orientations if set. Defaults to "250px auto".
+				</li>
+				<li>startingItem, a number that sets the default item, starts with index 1, defaults to 1.</li>
+				<li>separation, a number that defines the separation constant between images. Defaults to 175.</li>
+				<li>separationMultiplier, a number that defines the multiplier for separation via images from center. Defaults to 0.6.</li>
+				<li>horizonOffset, a number that sets the offset to the carousel horizon. Defaults to 0.</li>
+				<li>horizonOffsetMultiplier, a number that sets the multiplier on flanking items for the horizon constant. Defaults to 1.</li>
+				<li>sizeMultiplier, a number that sets the scaling for the more distant images. Defaults to 0.7.</li>
+				<li>opacityMultiplier, a number that sets the opacity multiplier for the more distant images. Defaults to 0.87.</li>
+				<li>horizon, a number that sets the horizon constant (main axis), defaults to 0.</li>
+				<li>flankingItems, a number that sets how many items are visible to left or right from the central item. Defaults to 3.</li>
+				<li>isVertical, a boolean value that allows to set carousel orientation to vertical. Defaults to false.</li>
+				<li>
+					forcedImageWidth and forcedImageHeight, are used to enforce image width and height, by default are disabled through being set to
+					0. Requires both properties to be set to work.
+				</li>
+				<li>
+					animationLength, specifies the transition between items length in milliseconds. The smooth transition is set through CSS property
+					on images. Defaults to 300.
+				</li>
+				<li>centralItemClassName, gives a class name to the central item. Defaults to "active".</li>
+				<li>allowSwitchingOrientation, a boolean value that allows to switch orientation of carousel through button. Defaults to false.</li>
+				<li>
+					movingToCenter, movedToCenter, movingFromCenter: three callbacks that are optional to pass and can be used to react on carousel's
+					navigation.
+				</li>
+			</ul>
+			<p>Here is a carousel only with allow switching orientation option:</p>
+			<PerspectiveCarousel allowSwitchingOrientation>
+				<CarouselItem className={styles["carousel-item"]}>
+					<img className={styles.img} src={image1} alt="Example Image" />
+				</CarouselItem>
+				<CarouselItem className={styles["carousel-item"]}>
+					<img className={styles.img} src={image2} alt="Example Image" />
+				</CarouselItem>
+				<CarouselItem className={styles["carousel-item"]}>
+					<img className={styles.img} src={image3} alt="Example Image" />
+				</CarouselItem>
+				<CarouselItem className={styles["carousel-item"]}>
+					<img className={styles.img} src={image4} alt="Example Image" />
+				</CarouselItem>
+				<CarouselItem className={styles["carousel-item"]}>
+					<img className={styles.img} src={image5} alt="Example Image" />
+				</CarouselItem>
+				<CarouselItem className={styles["carousel-item"]}>
+					<img className={styles.img} src={image6} alt="Example Image" />
+				</CarouselItem>
+				<CarouselItem className={styles["carousel-item"]}>
+					<img className={styles.img} src={image1} alt="Example Image" />
+				</CarouselItem>
+				<CarouselItem className={styles["carousel-item"]}>
+					<img className={styles.img} src={image2} alt="Example Image" />
+				</CarouselItem>
+				<CarouselItem className={styles["carousel-item"]}>
+					<img className={styles.img} src={image3} alt="Example Image" />
+				</CarouselItem>
+				<CarouselItem className={styles["carousel-item"]}>
+					<img className={styles.img} src={image4} alt="Example Image" />
+				</CarouselItem>
+				<CarouselItem className={styles["carousel-item"]}>
+					<img className={styles.img} src={image5} alt="Example Image" />
+				</CarouselItem>
+				<CarouselItem className={styles["carousel-item"]}>
+					<img className={styles.img} src={image6} alt="Example Image" />
+				</CarouselItem>
+			</PerspectiveCarousel>
+		</main>
+	);
+};
+
+export default Page;

--- a/react/src/docs/react/perspective-carousel/index.html
+++ b/react/src/docs/react/perspective-carousel/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Perspective Carousel</title>
+  <script defer src="./index.js"></script>
+  <script defer src="./perspective-carousel/index.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>

--- a/react/src/interfaces/component/perspectiveCarousel.ts
+++ b/react/src/interfaces/component/perspectiveCarousel.ts
@@ -1,0 +1,10 @@
+import { PerspectiveCarouselConfiguration as RootConfiguration } from "shared/component/perspectiveCarousel";
+import { GenericReactComponentProps } from "../generic/classNameFallthrough";
+import { ReactNode } from "react";
+
+export interface PerspectiveCarouselConfiguration extends RootConfiguration, GenericReactComponentProps {
+    children: ReactNode;
+    movingToCenter?(): void;
+    movedToCenter?(): void;
+    movingFromCenter(elementIndex?: number): void;
+}

--- a/vue/src/components/perspective-carousel/PerspectiveCarousel.vue
+++ b/vue/src/components/perspective-carousel/PerspectiveCarousel.vue
@@ -161,7 +161,6 @@ const moveItem = async (elementIndex: number, newPosition: number) => {
 	const itemState = elementsState.value[elementsAccessors.value.keys[elementIndex]];
 
 	const assignToItem = () => {
-		console.log(itemState.width);
 		item.styles = {
 			...item.styles,
 			left: `${itemState.left}px`,


### PR DESCRIPTION
## Description
This pull request implements the perspective carousel in React.

## Analysis
The perspective carousel was converted to React through the following steps:
1. Initially a solution with useReducer was considered to manage the re-rendering synchronization was considered, but due to the sheer amount of asynchronous and effectful code was disregarded in favor of refs with only one key useEffect call.
2. The initial structure was converted successfully, only with initialization at first.
3. useLayoutEffect was introduced with by that time a useReducer to force its iteration.
4. Getting entries, keys from the state have been tried both as useMemo and each-render invocations, but the final solution was an outer function that would isolate this logic from component.
5. The rest of code was converted, initially rendering a static carousel.
6. Buttons were added, a bug with cleared timeouts from useLayoutEffect has been successfully fixed.
7. A bug in which rotateCarousel was invoked on start was fixed, through creating a const enum with states, and depending on state different parts of code execute, thus securing that double rerenders in strict mode never break anything.
8. To allow switching orientation, isVertical was made a ref.

## Name of script
Perspective Carousel component.

## Browser Support
Issue occurred in 
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Opera

Possibly following:
- [x] IE
- [x] Safari
- [x] Safari for IOS
