### PR TITLE
implement sticky header in react

### DIFF
--- a/react/src/components/sticky-header/StickyHeader.tsx
+++ b/react/src/components/sticky-header/StickyHeader.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback, useRef } from "react";
+import { GenericReactComponentProps } from "../../interfaces/generic/classNameFallthrough";
+import { ContextLinkedItems, ExposedContextFunctions } from "../../interfaces/hooks/useLinkedItem";
+import { WithChildren } from "../../utils/utils";
+import { StickyHeaderMinimalConfiguration } from "shared/component/stickyHeader";
+import { generateThreshold } from "shared/interfaces/intersectionObserved";
+import { assertNonUndefined } from "shared/utils/utils";
+
+export const StickyHeader = ({
+	rootMargin = "0px",
+	ratio = 0.25,
+	...props
+}: WithChildren<Partial<StickyHeaderMinimalConfiguration>> & GenericReactComponentProps) => {
+	const headerElements = useRef<ExposedContextFunctions | null>(null);
+	const outerWrap = useRef<HTMLDivElement>(null);
+	const isFixed = useRef(false);
+	const intersectionObserver = useRef<IntersectionObserver>();
+
+	const setup = useCallback(() => {
+		const wrap = headerElements.current?.getState()?.["sticky-header"];
+		if (!wrap || !outerWrap.current) return;
+
+		const intersectionObserverInstance = new IntersectionObserver(
+			([entry]) => {
+				if (!outerWrap.current) return;
+
+				if (entry.intersectionRatio <= ratio && !isFixed.current) {
+					isFixed.current = true;
+					const { top, left, width, height } = wrap.element.current?.getBoundingClientRect() ?? {};
+					assertNonUndefined(wrap.element.current);
+					Object.assign(wrap.element.current.style, {
+						...wrap.styles,
+						position: "fixed",
+						top: `${top}px`,
+						left: `${left}px`,
+						width: `${width}px`,
+						height: `${height}px`,
+						zIndex: 9999
+					});
+
+					wrap.element.current.getBoundingClientRect();
+					headerElements.current?.updateState({
+						"sticky-header": {
+							element: wrap.element,
+							styles: {
+								position: "fixed",
+								top: 0,
+								left: 0,
+								right: 0,
+								width: "auto",
+								height: "auto",
+								zIndex: 9999
+							}
+						}
+					});
+				} else if (entry.intersectionRatio > ratio && isFixed.current) {
+					isFixed.current = false;
+					headerElements.current?.updateState({
+						"sticky-header": {
+							element: wrap.element,
+							styles: {
+								position: "static",
+								top: "",
+								left: "",
+								right: "",
+                                width: "",
+                                height: "",
+                                zIndex: "",
+							}
+						}
+					});
+				}
+			},
+			{
+				rootMargin,
+				threshold: generateThreshold()
+			}
+		);
+		intersectionObserverInstance.observe(outerWrap.current);
+		intersectionObserver.current = intersectionObserverInstance;
+	}, [ratio, rootMargin]);
+
+	return (
+		<ContextLinkedItems ref={headerElements} innerChildren={props.children} onAllElementsLoaded={setup}>
+			<div className={props.className} ref={outerWrap}>
+				{props.children}
+			</div>
+		</ContextLinkedItems>
+	);
+};

--- a/react/src/components/sticky-header/StickyHeaderElement.tsx
+++ b/react/src/components/sticky-header/StickyHeaderElement.tsx
@@ -1,0 +1,15 @@
+import React, { useRef } from "react";
+import { useLinkedItem } from "../../interfaces/hooks/useLinkedItem";
+import { GenericReactComponentProps } from "../../interfaces/generic/classNameFallthrough";
+import { WithChildren } from "react/src/utils/utils";
+
+export const StickyHeaderElement = (props: WithChildren<object> & GenericReactComponentProps) => {
+	const item = useRef<HTMLDivElement>(null);
+	const styleObject = useLinkedItem(() => "sticky-header", item);
+
+	return (
+		<div ref={item} style={styleObject} className={props.className}>
+			{props.children}
+		</div>
+	);
+};

--- a/react/src/docs/react/sticky-header/App.tsx
+++ b/react/src/docs/react/sticky-header/App.tsx
@@ -1,0 +1,22 @@
+import React, { Suspense } from "react";
+import { createRoot } from "react-dom/client";
+import "../../../components/reactEntry";
+import "../../../global.css";
+const Page = React.lazy(() => import("./Page"));
+const Header = React.lazy(() => import("../Header"));
+const Sidebar = React.lazy(() => import("../Sidebar"));
+
+const root = createRoot(document.getElementById("app") ?? document.documentElement);
+root.render(
+	<React.StrictMode>
+        <Suspense>
+            <Header />
+        </Suspense>
+        <Suspense>
+            <Sidebar activeLink="Sticky Header" />
+        </Suspense>
+		<Suspense>
+			<Page />
+		</Suspense>
+	</React.StrictMode>
+);

--- a/react/src/docs/react/sticky-header/Page.module.css
+++ b/react/src/docs/react/sticky-header/Page.module.css
@@ -1,0 +1,19 @@
+.sticky-header {
+	position: relative;
+	font-size: 24px;
+	line-height: 54px;
+	background-color: #e2e2e2;
+	text-align: center;
+	color: #333;
+	margin: 0;
+	z-index: 99;
+	transition: all 0.3s ease-in-out;
+}
+
+.sticky-header p {
+	margin: 0;
+}
+
+.sticky-header-wrap ~ p {
+	margin: 46px;
+}

--- a/react/src/docs/react/sticky-header/Page.tsx
+++ b/react/src/docs/react/sticky-header/Page.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import styles from "./Page.module.css";
+import { StickyHeader } from "../../../components/sticky-header/StickyHeader";
+import { StickyHeaderElement } from "../../../components/sticky-header/StickyHeaderElement";
+
+const Page = () => {
+	return (
+		<main className="main">
+			<h1 className="heading">Sticky Header</h1>
+			<p>
+				The sticky header component is a component that makes use of the IntersectionObserver API and wrapper custom component to keep track
+				of when intersection changes and quickly keep track of which state the header should be in. The custom component represents the
+				scrolling point, and its first nested element is the sticky header. As soon as header is not fully visible as specified by user, the
+				sticky header is then automatically re-updated. Another feature of this component is the smooth animation from the non-sticky state
+				to the fixed state. This component accepts the following props:
+			</p>
+			<ul>
+				<li>rootMargin, a string that is passed to the IntersectionObserver as the root margin.</li>
+				<li>
+					ratio, a number in range of 0 to 1 that specifies which ratio of the component should be fully visible for state to change. The
+					default value is 0.25.
+				</li>
+			</ul>
+			<p>Here you can see an example of this component with default settings:</p>
+			<StickyHeader className={styles["sticky-header-wrap"]}>
+				<StickyHeaderElement className={styles["sticky-header"]}>
+					<p>Sticky Header</p>
+				</StickyHeaderElement>
+			</StickyHeader>
+			<p>
+				Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita, veritatis soluta eligendi inventore ratione autem praesentium
+				asperiores accusamus recusandae, alias quos deserunt adipisci voluptate pariatur error fuga dicta esse facilis.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita, veritatis soluta eligendi inventore ratione autem praesentium
+				asperiores accusamus recusandae, alias quos deserunt adipisci voluptate pariatur error fuga dicta esse facilis.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita, veritatis soluta eligendi inventore ratione autem praesentium
+				asperiores accusamus recusandae, alias quos deserunt adipisci voluptate pariatur error fuga dicta esse facilis.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita, veritatis soluta eligendi inventore ratione autem praesentium
+				asperiores accusamus recusandae, alias quos deserunt adipisci voluptate pariatur error fuga dicta esse facilis.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita, veritatis soluta eligendi inventore ratione autem praesentium
+				asperiores accusamus recusandae, alias quos deserunt adipisci voluptate pariatur error fuga dicta esse facilis.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita, veritatis soluta eligendi inventore ratione autem praesentium
+				asperiores accusamus recusandae, alias quos deserunt adipisci voluptate pariatur error fuga dicta esse facilis.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita, veritatis soluta eligendi inventore ratione autem praesentium
+				asperiores accusamus recusandae, alias quos deserunt adipisci voluptate pariatur error fuga dicta esse facilis.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita, veritatis soluta eligendi inventore ratione autem praesentium
+				asperiores accusamus recusandae, alias quos deserunt adipisci voluptate pariatur error fuga dicta esse facilis.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita, veritatis soluta eligendi inventore ratione autem praesentium
+				asperiores accusamus recusandae, alias quos deserunt adipisci voluptate pariatur error fuga dicta esse facilis.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita, veritatis soluta eligendi inventore ratione autem praesentium
+				asperiores accusamus recusandae, alias quos deserunt adipisci voluptate pariatur error fuga dicta esse facilis.
+			</p>
+		</main>
+	);
+};
+
+export default Page;

--- a/react/src/docs/react/sticky-header/index.html
+++ b/react/src/docs/react/sticky-header/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sticky Header Component</title>
+  <script defer src="./index.js"></script>
+  <script defer src="./sticky-header/index.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>


### PR DESCRIPTION
## Description
This pull request implements the sticky header in React.

## Analysis
The sticky header has been converted to React through the following steps:
1. The initial structure was converted, without desired animation, however.
2. A solution with useEffect was unsuccessfully tried.
3. The solution was found to use refs as an escape hatch to synchronously set element's styles and then rerender all the styles. This solution was surprisingly found to be bullet proof, since it never relies on the previous state and on the synchronous calls of intersection observer, guaranteeing perfect sync with state.

## Name of script
Sticky Header Component.

## Browser Support
Issue occurred in 
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Opera

Possibly following:
- [x] IE
- [x] Safari
- [x] Safari for IOS
