### PR TITLE
Improve carousel general interface typings

### DIFF
--- a/lit/src/components/backface-carousel/backfaceCarousel.ts
+++ b/lit/src/components/backface-carousel/backfaceCarousel.ts
@@ -15,40 +15,41 @@ import { range } from "lit/directives/range.js";
 import { classMap } from "lit/directives/class-map.js";
 
 export class BackfaceCarousel extends LinkedCarouselMixin(LitElement) implements CarouselConfiguration {
-	static styles = css`
-		:host {
-			display: block;
-		}
+	static styles = [
+		css`
+			:host {
+				display: block;
+			}
 
-		.backface-carousel {
-			display: flex;
-			width: auto;
-			height: 100%;
-			flex-direction: column;
-			align-items: center;
-			perspective: 500px;
-			overflow: hidden;
-			padding: 20px;
-		}
+			.backface-carousel {
+				display: flex;
+				width: auto;
+				height: 100%;
+				flex-direction: column;
+				align-items: center;
+				perspective: 500px;
+				overflow: hidden;
+				padding: 20px;
+			}
 
-		.backface-carousel--vertical {
-			margin-top: 10%;
-			height: 33vw;
-			overflow: visible;
-		}
+			.backface-carousel--vertical {
+				margin-top: 10%;
+				height: 33vw;
+				overflow: visible;
+			}
 
-		.backface-carousel-items {
-			width: 40%;
-			transform-style: preserve-3d;
-			transition: all 0.5s;
-			padding: 0;
-			list-style-type: none;
-			margin: 0 auto;
-			flex: 0 0 auto;
-		}
-
-		${carouselControlsStyles}
-	`;
+			.backface-carousel-items {
+				width: 40%;
+				transform-style: preserve-3d;
+				transition: all 0.5s;
+				padding: 0;
+				list-style-type: none;
+				margin: 0 auto;
+				flex: 0 0 auto;
+			}
+		`,
+		carouselControlsStyles
+	];
 
 	@property({ type: Boolean })
 	isVertical = false;
@@ -74,7 +75,7 @@ export class BackfaceCarousel extends LinkedCarouselMixin(LitElement) implements
 		},
 		250
 	);
-	
+
 	rotateCarousel(newCurrentImage: number) {
 		const theta = (2 * Math.PI) / this.itemValues.length;
 		this._carouselStyles.transform = `rotate${this.isVertical ? "X" : "Y"}(${String(newCurrentImage * -theta)}rad)`;

--- a/lit/src/components/backface-carousel/backfaceCarousel.ts
+++ b/lit/src/components/backface-carousel/backfaceCarousel.ts
@@ -6,8 +6,15 @@ import { LinkedCarouselMixin } from "../../interfaces/hooks/linkedItems";
 import { BackfaceCarouselItem } from "./backfaceCarouselItem";
 import { IntervalController } from "../../interfaces/hooks/intervalController";
 import { ResizeController } from "../../interfaces/hooks/resizeController";
+import { CarouselConfiguration, CarouselConfigurationAutoplayOptions } from "shared/interfaces/carousel";
+import { AutoplayController } from "../../interfaces/hooks/autoplayController";
+import { getCurrentItemInfo } from "shared/utils/carousel";
+import { when } from "lit/directives/when.js";
+import { map } from "lit/directives/map.js";
+import { range } from "lit/directives/range.js";
+import { classMap } from "lit/directives/class-map.js";
 
-export class BackfaceCarousel extends LinkedCarouselMixin(LitElement) {
+export class BackfaceCarousel extends LinkedCarouselMixin(LitElement) implements CarouselConfiguration {
 	static styles = css`
 		:host {
 			display: block;
@@ -45,19 +52,29 @@ export class BackfaceCarousel extends LinkedCarouselMixin(LitElement) {
 
 	@property({ type: Boolean })
 	isVertical = false;
+	@property({ type: Boolean })
+	allowSwitchingOrientation = false;
+	@property({ type: Boolean })
+	showArrows = false;
+	@property({ type: Boolean })
+	showToggles = false;
+	@property({ type: Object })
+	autoplay?: CarouselConfigurationAutoplayOptions;
+
 	@state()
 	protected _carouselStyles: StyleInfo = {};
 	@state()
 	private _currentItem = 0;
 
-	private intervalController = new IntervalController(
+	private _autoplayController!: AutoplayController;
+	private _intervalController = new IntervalController(
 		this,
 		() => {
 			this.setupCarousel();
 		},
 		250
 	);
-
+	
 	rotateCarousel(newCurrentImage: number) {
 		const theta = (2 * Math.PI) / this.itemValues.length;
 		this._carouselStyles.transform = `rotate${this.isVertical ? "X" : "Y"}(${String(newCurrentImage * -theta)}rad)`;
@@ -90,54 +107,103 @@ export class BackfaceCarousel extends LinkedCarouselMixin(LitElement) {
 
 	protected firstUpdated(): void {
 		new ResizeController(this, this.setupCarousel.bind(this));
+		this._autoplayController = new AutoplayController(this, {
+			autoplay: this.autoplay,
+			nextSlide: this.nextSlide.bind(this),
+			previousSlide: this.previousSlide.bind(this)
+		});
+
 		this.setupCarousel();
 	}
 
 	nextSlide() {
-		this.intervalController.abortInterval();
+		this._intervalController.abortInterval();
 		this.rotateCarousel(this._currentItem + 1);
 	}
 
 	previousSlide() {
-		this.intervalController.abortInterval();
+		this._intervalController.abortInterval();
 		this.rotateCarousel(this._currentItem - 1);
 	}
 
 	switchPerspective() {
-		this.intervalController.abortInterval();
+		this._intervalController.abortInterval();
 		this.isVertical = !this.isVertical;
 		this.setupCarousel();
 	}
 
 	render() {
+		const { realCurrentItem, childrenLength, getCurrentItem } = getCurrentItemInfo({
+			childrenLength: this.itemKeys.length,
+			currentItem: this._currentItem
+		});
+
 		return html`
 			<div class="backface-carousel ${this.isVertical ? "backface-carousel--vertical" : ""}">
 				<ul class="backface-carousel-items" style=${styleMap(this._carouselStyles)}>
 					<slot></slot>
 				</ul>
 			</div>
-			<div class="carousel-controls">
-				<button
-					class="carousel-controls__previous-button"
-					@click=${() => {
-						this.previousSlide();
-					}}
-				></button>
-				<button
-					class="carousel-controls__perspective-button"
-					@click=${() => {
-						this.switchPerspective();
-					}}
-				>
-					Switch
-				</button>
-				<button
-					class="carousel-controls__next-button"
-					@click=${() => {
-						this.nextSlide();
-					}}
-				></button>
-			</div>
+			${when(
+				this.showArrows || this.allowSwitchingOrientation,
+				() =>
+					html`<div class="carousel-controls">
+						${when(
+							this.showArrows,
+							() =>
+								html`<button
+									class="carousel-controls__previous-button"
+									@click=${() => {
+										this._autoplayController.abortTimeout();
+										this.previousSlide();
+									}}
+								></button>`
+						)}
+						${when(
+							this.allowSwitchingOrientation,
+							() =>
+								html`<button
+									class="carousel-controls__perspective-button"
+									@click=${() => {
+										this._autoplayController.abortTimeout();
+										this.switchPerspective();
+									}}
+								>
+									Switch
+								</button>`
+						)}
+						${when(
+							this.showArrows,
+							() =>
+								html`<button
+									class="carousel-controls__next-button"
+									@click=${() => {
+										this._autoplayController.abortTimeout();
+										this.nextSlide();
+									}}
+								></button>`
+						)}
+					</div>`
+			)}
+			${when(
+				this.showToggles,
+				() =>
+					html`<ul class="carousel-controls__toggles">
+						${map(
+							range(childrenLength),
+							(i) =>
+								html`<li
+									class="carousel-controls__toggle ${classMap({
+										"carousel-controls__toggle--active": i === realCurrentItem
+									})}"
+									@click=${() => {
+										this._autoplayController.abortTimeout();
+										this.rotateCarousel(getCurrentItem(i));
+									}}
+								></li>`
+						)}
+					</ul>`
+			)}
 		`;
 	}
 }

--- a/lit/src/components/gallery-carousel/galleryCarousel.ts
+++ b/lit/src/components/gallery-carousel/galleryCarousel.ts
@@ -13,93 +13,94 @@ import { CarouselConfigurationAutoplayOptions } from "shared/interfaces/carousel
 import { carouselControlsStyles } from "../../interfaces/generic/carousel";
 
 export class GalleryCarouselComponent extends LinkedCarouselMixin(LitElement) implements GalleryCarouselConfiguration {
-	static styles = css`
-		:host {
-			position: relative;
-		}
+	static styles = [
+		carouselControlsStyles,
+		css`
+			:host {
+				position: relative;
+			}
 
-		${carouselControlsStyles}
+			.gallery {
+				position: relative;
+				overflow: hidden;
+				width: 100%;
+				height: 100%;
+			}
 
-		.gallery {
-			position: relative;
-			overflow: hidden;
-			width: 100%;
-			height: 100%;
-		}
+			.gallery-list {
+				position: relative;
+				display: flex;
+				width: inherit;
+				height: inherit;
+				margin: 0;
+				padding: 0;
+				list-style-type: none;
+				font-size: 0;
+				white-space: nowrap;
+				line-height: 1;
+				z-index: 10;
+			}
 
-		.gallery-list {
-			position: relative;
-			display: flex;
-			width: inherit;
-			height: inherit;
-			margin: 0;
-			padding: 0;
-			list-style-type: none;
-			font-size: 0;
-			white-space: nowrap;
-			line-height: 1;
-			z-index: 10;
-		}
+			.gallery-list--vertical {
+				flex-direction: column;
+			}
 
-		.gallery-list--vertical {
-			flex-direction: column;
-		}
+			.gallery-toggles {
+				position: relative;
+				z-index: 2;
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				list-style-type: none;
+				padding: 0;
+				gap: 0.3rem;
+			}
 
-		.gallery-toggles {
-			position: relative;
-			z-index: 2;
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			list-style-type: none;
-			padding: 0;
-			gap: 0.3rem;
-		}
+			.gallery-toggle {
+				width: 10px;
+				height: 10px;
+				cursor: pointer;
+				border: 1px solid #e2e2e2;
+				border-radius: 50%;
+			}
 
-		.gallery-toggle {
-			width: 10px;
-			height: 10px;
-			cursor: pointer;
-			border: 1px solid #e2e2e2;
-			border-radius: 50%;
-		}
+			.gallery-toggle--active {
+				background-color: #2390bb;
+			}
 
-		.gallery-toggle--active {
-			background-color: #2390bb;
-		}
+			.gallery-controls {
+				position: absolute;
+				z-index: 1;
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				left: -10%;
+				right: -10%;
+				top: 0;
+				bottom: 0;
+			}
 
-		.gallery-controls {
-			position: absolute;
-			z-index: 1;
-			display: flex;
-			align-items: center;
-			justify-content: space-between;
-			left: -10%;
-			right: -10%;
-			top: 0;
-			bottom: 0;
-		}
+			.gallery-controls__next-button {
+				width: 0;
+				height: 0;
+				border-style: solid;
+				border-width: 7.5px 0 7.5px 13px;
+				border-color: transparent transparent transparent #fff;
+				background: none;
+				cursor: pointer;
+			}
 
-		.gallery-controls__next-button {
-			width: 0;
-			height: 0;
-			border-style: solid;
-			border-width: 7.5px 0 7.5px 13px;
-			border-color: transparent transparent transparent #fff;
-			background: none;
-			cursor: pointer;
-		}
-
-		.gallery-controls__previous-button {
-			width: 0;
-			height: 0;
-			border-style: solid;
-			border-width: 7.5px 13px 7.5px 0;
-			border-color: transparent #fff transparent transparent;
-			background: none;
-			cursor: pointer;
-		}
-	`;
+			.gallery-controls__previous-button {
+				width: 0;
+				height: 0;
+				border-style: solid;
+				border-width: 7.5px 13px 7.5px 0;
+				border-color: transparent #fff transparent transparent;
+				background: none;
+				cursor: pointer;
+			}
+		`
+	];
 
 	@property({ type: Boolean })
 	smoothDiametralTransition = false;

--- a/lit/src/components/gallery-carousel/galleryCarouselItem.ts
+++ b/lit/src/components/gallery-carousel/galleryCarouselItem.ts
@@ -11,7 +11,7 @@ export class GalleryCarouselItem extends LinkedItemMixin(LitElement) {
 		.gallery-carousel-item {
 			all: inherit;
 			display: inline-block;
-			width: 100%;
+			min-width: 100%;
 			height: 100%;
 		}
 

--- a/lit/src/components/menu-carousel/menuCarousel.ts
+++ b/lit/src/components/menu-carousel/menuCarousel.ts
@@ -243,7 +243,7 @@ export class MenuCarouselComponent extends LinkedCarouselMixin(LitElement) imple
 				() => html`
 					<ul class="carousel-controls__toggles">
 						${map(
-							range(this.itemKeys.length),
+							range(childrenLength),
 							(i) =>
 								html`<li
 									class="carousel-controls__toggle ${classMap({

--- a/lit/src/components/one-page-scroll/onePageScroll.ts
+++ b/lit/src/components/one-page-scroll/onePageScroll.ts
@@ -10,42 +10,42 @@ import { map } from "lit/directives/map.js";
 import { range } from "lit/directives/range.js";
 
 export class OnePageScrollComponent extends LitElement implements OnePageScrollConfiguration {
-	static styles = css`
-		:host {
-			display: block;
-		}
+	static styles = [
+		carouselControlsStyles,
+		css`
+			:host {
+				display: block;
+			}
+			.wrap {
+				width: 100%;
+				height: 100%;
+				min-height: 100%;
+				max-height: 100%;
+				overflow-x: hidden;
+				overflow-y: scroll;
+			}
 
-		${carouselControlsStyles}
+			.wrap--horizontal {
+				display: flex;
+				overflow-x: scroll;
+				overflow-y: hidden;
+			}
 
-		.wrap {
-			width: 100%;
-			height: 100%;
-			min-height: 100%;
-			max-height: 100%;
-			overflow-x: hidden;
-			overflow-y: scroll;
-		}
+			.wrap--no-scrollbar {
+				overflow: hidden;
+			}
 
-		.wrap--horizontal {
-			display: flex;
-			overflow-x: scroll;
-			overflow-y: hidden;
-		}
+			.carousel-controls {
+				margin-top: 12px;
+			}
 
-		.wrap--no-scrollbar {
-			overflow: hidden;
-		}
-
-		.carousel-controls {
-			margin-top: 12px;
-		}
-
-		::slotted(*) {
-			display: block;
-			flex: 1 0 0;
-			box-sizing: border-box;
-		}
-	`;
+			::slotted(*) {
+				display: block;
+				flex: 1 0 0;
+				box-sizing: border-box;
+			}
+		`
+	];
 
 	@property({ type: Number })
 	duration = 500;

--- a/lit/src/components/one-page-scroll/onePageScroll.ts
+++ b/lit/src/components/one-page-scroll/onePageScroll.ts
@@ -1,14 +1,21 @@
-import { LitElement, css, html } from "lit";
-import { property, query, queryAssignedElements } from "lit/decorators.js";
+import { LitElement, PropertyValues, css, html } from "lit";
+import { property, query, queryAssignedElements, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
+import { when } from "lit/directives/when.js";
+import { carouselControlsStyles } from "../../interfaces/generic/carousel";
+import { AutoplayController } from "../../interfaces/hooks/autoplayController";
 import { OnePageScrollConfiguration, easeInOutQuad } from "shared/component/onePageScroll";
-import { CarouselDirection } from "shared/interfaces/carousel";
+import { CarouselConfigurationAutoplayOptions, CarouselDirection } from "shared/interfaces/carousel";
+import { map } from "lit/directives/map.js";
+import { range } from "lit/directives/range.js";
 
 export class OnePageScrollComponent extends LitElement implements OnePageScrollConfiguration {
 	static styles = css`
 		:host {
 			display: block;
 		}
+
+		${carouselControlsStyles}
 
 		.wrap {
 			width: 100%;
@@ -29,6 +36,10 @@ export class OnePageScrollComponent extends LitElement implements OnePageScrollC
 			overflow: hidden;
 		}
 
+		.carousel-controls {
+			margin-top: 12px;
+		}
+
 		::slotted(*) {
 			display: block;
 			flex: 1 0 0;
@@ -36,30 +47,56 @@ export class OnePageScrollComponent extends LitElement implements OnePageScrollC
 		}
 	`;
 
-	@property({ type: Boolean })
-	isHorizontal = false;
 	@property({ type: Number })
 	duration = 500;
 	@property({ type: Number })
 	increment = 6;
 	@property({ type: Boolean })
 	noScrollbar = false;
+	@property({ type: Boolean })
+	allowSwitchingOrientation = false;
+	@property({ type: Boolean })
+	isVertical = false;
+	@property({ type: Boolean })
+	showArrows = false;
+	@property({ type: Boolean })
+	showToggles = false;
+	@property({ type: Object })
+	autoplay?: CarouselConfigurationAutoplayOptions;
 
-	private _selectedItem = 0;
+	@state()
+	private _currentItem = 0;
+	private _previousItem = 0;
 	private _isScrolling = false;
+	private _autoplayController!: AutoplayController;
 
 	@queryAssignedElements()
 	_onePageScrollElements!: HTMLElement[];
 	@query(".wrap")
 	_wrapElement!: HTMLDivElement;
 
+	protected firstUpdated(): void {
+		this.requestUpdate();
+		this._autoplayController = new AutoplayController(this, {
+			autoplay: this.autoplay,
+			nextSlide: this.nextSlide.bind(this),
+			previousSlide: this.previousSlide.bind(this)
+		});
+	}
+
+	protected updated(_changedProperties: PropertyValues): void {
+		if (_changedProperties.has("isVertical") && _changedProperties.get("isVertical") !== undefined) {
+			this.navigateToItem(this._previousItem);
+		}
+	}
+
 	protected smoothScrollTo(to: number) {
 		this._isScrolling = true;
 		const wrap = this._wrapElement;
-		const start = this.isHorizontal ? wrap.scrollLeft : wrap.scrollTop,
+		const start = this.isVertical ? wrap.scrollTop : wrap.scrollLeft,
 			change = to - start;
 		let currentTime = 0;
-		const property = this.isHorizontal ? "scrollLeft" : "scrollTop";
+		const property = this.isVertical ? "scrollTop" : "scrollLeft";
 
 		const animateScroll = () => {
 			currentTime += this.increment;
@@ -79,42 +116,128 @@ export class OnePageScrollComponent extends LitElement implements OnePageScrollC
 
 	protected scrollSlide(direction: CarouselDirection) {
 		if (this._isScrolling) return;
-		this._selectedItem += direction;
+		this._currentItem += direction;
 		this.smoothScrollTo(
-			this._onePageScrollElements[this._selectedItem][this.isHorizontal ? "offsetWidth" : "offsetHeight"] * this._selectedItem
+			this._onePageScrollElements[this._currentItem][this.isVertical ? "offsetHeight" : "offsetWidth"] * this._currentItem
 		);
 	}
 
-	private onWheel(event: WheelEvent) {
+	private nextSlide() {
 		const items = this._onePageScrollElements;
+		if (this._currentItem >= items.length - 1) {
+			if (!this._isScrolling) this.smoothScrollTo((this._currentItem = 0));
+		} else this.scrollSlide(CarouselDirection.FORWARDS);
+	}
+
+	private previousSlide() {
+		const items = this._onePageScrollElements;
+		if (this._currentItem === 0) {
+			if (!this._isScrolling) {
+				this._currentItem = items.length - 1;
+				this.smoothScrollTo(
+					(this.isVertical ? this._wrapElement.scrollHeight : this._wrapElement.scrollWidth) -
+						(this.isVertical ? items[0].offsetHeight : items[0].offsetWidth)
+				);
+			}
+		} else this.scrollSlide(CarouselDirection.BACKWARDS);
+	}
+
+	private navigateToItem(item: number) {
+		if (this._isScrolling) return;
+		const element = this._onePageScrollElements[0];
+		this._currentItem = item;
+		this.smoothScrollTo(element[this.isVertical ? "offsetHeight" : "offsetWidth"] * item);
+		this._autoplayController.abortTimeout();
+	}
+
+	private switchOrientation() {
+		if (this._isScrolling) return;
+		this._previousItem = this._currentItem;
+		this._currentItem = 0;
+		this._autoplayController.abortTimeout();
+		this.isVertical = !this.isVertical;
+	}
+
+	private onWheel(event: WheelEvent) {
 		if (event.deltaY > 0) {
-			if (this._selectedItem >= items.length - 1) {
-				if (!this._isScrolling) this.smoothScrollTo((this._selectedItem = 0));
-			} else this.scrollSlide(CarouselDirection.FORWARDS);
-		} else {
-			if (this._selectedItem === 0) {
-				if (!this._isScrolling) {
-					this._selectedItem = items.length - 1;
-					this.smoothScrollTo(
-						(this.isHorizontal ? this._wrapElement.scrollWidth : this._wrapElement.scrollHeight) -
-							(this.isHorizontal ? items[0].offsetWidth : items[0].offsetHeight)
-					);
-				}
-			} else this.scrollSlide(CarouselDirection.BACKWARDS);
-		}
+			this.nextSlide();
+		} else this.previousSlide();
+		this._autoplayController.abortTimeout();
 	}
 
 	render() {
 		return html`<div
-			class="wrap ${classMap({ "wrap--horizontal": this.isHorizontal, "wrap--no-scrollbar": this.noScrollbar })}"
-			@wheel=${{
-				handleEvent: (e: WheelEvent) => {
-					this.onWheel(e);
-				},
-				passive: true
-			}}
-		>
-			<slot></slot>
-		</div>`;
+				class="wrap ${classMap({ "wrap--horizontal": !this.isVertical, "wrap--no-scrollbar": this.noScrollbar })}"
+				@wheel=${{
+					handleEvent: (e: WheelEvent) => {
+						this.onWheel(e);
+					},
+					passive: true
+				}}
+			>
+				<slot></slot>
+			</div>
+			${when(
+				this.allowSwitchingOrientation || this.showArrows,
+				() => html`
+					<div class="carousel-controls">
+						${when(
+							this.showArrows,
+							() => html`
+								<button
+									class="carousel-controls__previous-button"
+									@click=${() => {
+										this._autoplayController.abortTimeout();
+										this.previousSlide();
+									}}
+								></button>
+							`
+						)}
+						${when(
+							this.allowSwitchingOrientation,
+							() =>
+								html`<button
+									class="carousel-controls__perspective-button"
+									@click=${() => {
+										this._autoplayController.abortTimeout();
+										this.switchOrientation();
+									}}
+								>
+									Switch
+								</button>`
+						)}
+						${when(
+							this.showArrows,
+							() => html`
+								<button
+									class="carousel-controls__next-button"
+									@click=${() => {
+										this._autoplayController.abortTimeout();
+										this.nextSlide();
+									}}
+								></button>
+							`
+						)}
+					</div>
+				`
+			)}
+			${when(
+				this.showToggles,
+				() =>
+					html`<ul class="carousel-controls__toggles">
+						${map(
+							range(this._onePageScrollElements.length),
+							(i) =>
+								html`<li
+									class="carousel-controls__toggle ${classMap({
+										"carousel-controls__toggle--active": i === this._currentItem
+									})}"
+									@click=${() => {
+										this.navigateToItem(i);
+									}}
+								></li>`
+						)}
+					</ul>`
+			)} `;
 	}
 }

--- a/lit/src/components/perspective-carousel/perspectiveCarousel.ts
+++ b/lit/src/components/perspective-carousel/perspectiveCarousel.ts
@@ -1,13 +1,19 @@
 import { LitElement, html, css } from "lit";
-import { property, query } from "lit/decorators.js";
+import { property, query, state } from "lit/decorators.js";
 import { PerspectiveCarouselConfiguration, PerspectiveCarouselItemState } from "shared/component/perspectiveCarousel";
 import { styleMap } from "lit/directives/style-map.js";
-import { CarouselDirection } from "shared/interfaces/carousel";
+import { CarouselConfigurationAutoplayOptions, CarouselDirection } from "shared/interfaces/carousel";
 import { carouselControlsStyles } from "../../interfaces/generic/carousel";
 import { resetInternalLitState } from "../../interfaces/component/perspectiveCarousel";
 import { CarouselItem, LinkedCarouselMixin } from "../../interfaces/hooks/linkedItems";
 import { MovedToCenterEvent, MovingFromCenterEvent, MovingToCenterEvent } from "./events";
 import { ResizeController } from "../../interfaces/hooks/resizeController";
+import { when } from "lit/directives/when.js";
+import { map } from "lit/directives/map.js";
+import { range } from "lit/directives/range.js";
+import { getCurrentItemInfo } from "shared/utils/carousel";
+import { classMap } from "lit/directives/class-map.js";
+import { AutoplayController } from "../../interfaces/hooks/autoplayController";
 
 export class PerspectiveCarouselComponent extends LinkedCarouselMixin(LitElement) implements PerspectiveCarouselConfiguration {
 	static styles = css`
@@ -25,11 +31,11 @@ export class PerspectiveCarouselComponent extends LinkedCarouselMixin(LitElement
 
 		${carouselControlsStyles}
 
-		.carousel-controls {
+		.root-carousel-controls {
 			position: absolute;
 			left: 40%;
-			transform: translateX(-50%);
-			bottom: -5%;
+			transform: translate(-50%, 100%);
+			bottom: 0;
 			z-index: 99;
 		}
 	`;
@@ -68,9 +74,21 @@ export class PerspectiveCarouselComponent extends LinkedCarouselMixin(LitElement
 	animationLength = 300;
 	@property({ type: Boolean })
 	allowSwitchingOrientation = false;
+	@property({ type: Boolean })
+	showArrows = false;
+	@property({ type: Boolean })
+	showToggles = false;
+	@property({ type: Object })
+	autoplay?: CarouselConfigurationAutoplayOptions;
 
+	@state()
+	private _currentItem = 0;
+	private _isNavigatingByToggles = false;
+	private _isStateCurrentlyMoving?: Promise<void>;
+	private _resolveStateCurrentlyMoving?: () => void;
 	protected _internalState = resetInternalLitState<number>();
 	protected _elementsState: Record<string, Partial<PerspectiveCarouselItemState>> = {};
+	private _autoplayController!: AutoplayController;
 
 	@query(".images")
 	protected _parentElement!: HTMLDivElement;
@@ -204,6 +222,9 @@ export class PerspectiveCarouselComponent extends LinkedCarouselMixin(LitElement
 		this._internalState.currentlyMoving = true;
 		this._internalState.itemsAnimating = 0;
 		this._internalState.carouselRotationsLeft++;
+		this._isStateCurrentlyMoving = new Promise((resolve) => {
+			this._resolveStateCurrentlyMoving = resolve;
+		});
 
 		this.itemKeys.forEach((key, i) => {
 			const currentPosition = this._elementsState[key].currentPosition ?? NaN;
@@ -222,7 +243,11 @@ export class PerspectiveCarouselComponent extends LinkedCarouselMixin(LitElement
 
 		this._internalState.itemsAnimating--;
 		itemState.currentPosition = newPosition;
-		if (newPosition === 0) this._internalState.currentCenterItem = elementIndex;
+		if (newPosition === 0) {
+			this._internalState.currentCenterItem = elementIndex;
+			this._currentItem = this._internalState.currentCenterItem;
+		}
+
 		if (this._internalState.itemsAnimating) return;
 		this._internalState.currentlyMoving = false;
 
@@ -232,6 +257,11 @@ export class PerspectiveCarouselComponent extends LinkedCarouselMixin(LitElement
 				this.dispatchEvent(new MovedToCenterEvent());
 			} else this._internalState.performingSetup = false;
 		} else this.rotateCarousel();
+
+		if (this._isStateCurrentlyMoving && this._resolveStateCurrentlyMoving) {
+			this._resolveStateCurrentlyMoving();
+			this._isStateCurrentlyMoving = this._resolveStateCurrentlyMoving = undefined;
+		}
 	}
 
 	protected moveItem(elementIndex: number, newPosition: number) {
@@ -258,6 +288,12 @@ export class PerspectiveCarouselComponent extends LinkedCarouselMixin(LitElement
 				zIndex: String(itemState.depth ?? "")
 			};
 			assignToItem();
+			if (newPosition === 0) {
+				window.setTimeout(() => {
+					this._currentItem = elementIndex;
+				}, 1);
+			}
+
 			setTimeout(() => {
 				this.itemAnimationComplete(elementIndex, newPosition);
 			}, this.animationLength);
@@ -325,6 +361,12 @@ export class PerspectiveCarouselComponent extends LinkedCarouselMixin(LitElement
 
 	protected firstUpdated(): void {
 		new ResizeController(this, this.initCarousel.bind(this));
+		this._autoplayController = new AutoplayController(this, {
+			autoplay: this.autoplay,
+			previousSlide: this.previousSlide.bind(this),
+			nextSlide: this.nextSlide.bind(this)
+		});
+
 		this.initCarousel().catch((e: unknown) => {
 			console.trace(e);
 		});
@@ -347,12 +389,29 @@ export class PerspectiveCarouselComponent extends LinkedCarouselMixin(LitElement
 		this._internalState.currentDirection = direction;
 	}
 
-	nextItem() {
+	async navigateByDifference(difference: number) {
+		this._isNavigatingByToggles = true;
+		const direction = Math.sign(difference);
+		if (direction === 1 || direction === -1) {
+			this._internalState.currentDirection = direction;
+		} else {
+			this._internalState.currentDirection = CarouselDirection.STILL;
+			return;
+		}
+
+		for (let i = 0; i < Math.abs(difference); i++) {
+			this.rotateCarousel();
+			await this._isStateCurrentlyMoving;
+			this._autoplayController.abortTimeout();
+		}
+	}
+
+	nextSlide() {
 		this.moveOnce(CarouselDirection.FORWARDS);
 		this.rotateCarousel();
 	}
 
-	previousItem() {
+	previousSlide() {
 		this.moveOnce(CarouselDirection.BACKWARDS);
 		this.rotateCarousel();
 	}
@@ -360,37 +419,93 @@ export class PerspectiveCarouselComponent extends LinkedCarouselMixin(LitElement
 	switchOrientation() {
 		if (!this.allowSwitchingOrientation) return;
 		this.isVertical = !this.isVertical;
+		this._internalState.currentDirection = CarouselDirection.STILL;
 		this.rotateCarousel();
 	}
 
 	render() {
+		const { realCurrentItem, childrenLength, getCurrentItem } = getCurrentItemInfo({
+			childrenLength: this.itemKeys.length,
+			currentItem: this._currentItem
+		});
+
 		return html`<div class="images" style=${styleMap({ height: this.imageSize, margin: this.margin })}>
 				<slot></slot>
 			</div>
-			<div class="carousel-controls">
-				<button
-					class="carousel-controls__previous-button"
-					@click="${() => {
-						this.previousItem();
-					}}"
-				></button>
-				${this.allowSwitchingOrientation
-					? html`<button
-							class="carousel-controls__perspective-button"
-							@click="${() => {
-								this.switchOrientation();
-							}}"
-						>
-							Switch
-						</button>`
-					: ""}
-				<button
-					class="carousel-controls__next-button"
-					@click="${() => {
-						this.nextItem();
-					}}"
-				></button>
-			</div>`;
+			${when(
+				this.allowSwitchingOrientation || this.showArrows || this.showToggles,
+				() =>
+					html`<div class="root-carousel-controls">
+						${when(
+							this.allowSwitchingOrientation || this.showArrows,
+							() =>
+								html`<div class="carousel-controls">
+									${when(
+										this.showArrows,
+										() =>
+											html`<button
+												class="carousel-controls__previous-button"
+												@click="${() => {
+													this._autoplayController.abortTimeout();
+													this.previousSlide();
+												}}"
+											></button>`
+									)}
+									${when(
+										this.allowSwitchingOrientation,
+										() =>
+											html`<button
+												class="carousel-controls__perspective-button"
+												@click="${() => {
+													this._autoplayController.abortTimeout();
+													this.switchOrientation();
+												}}"
+											>
+												Switch
+											</button>`
+									)}
+									${when(
+										this.allowSwitchingOrientation,
+										() =>
+											html`<button
+												class="carousel-controls__next-button"
+												@click="${() => {
+													this._autoplayController.abortTimeout();
+													this.nextSlide();
+												}}"
+											></button>`
+									)}
+								</div>`
+						)}
+						${when(
+							this.showToggles,
+							() =>
+								html`<ul class="carousel-controls__toggles">
+									${map(
+										range(childrenLength),
+										(i) =>
+											html`<li
+												class="carousel-controls__toggle ${classMap({
+													"carousel-controls__toggle--active": i === realCurrentItem
+												})}"
+												@click=${() => {
+													if (this._isNavigatingByToggles) return;
+													this._autoplayController.abortTimeout();
+													const difference = (getCurrentItem(i) % childrenLength) - (this._currentItem % childrenLength);
+													this.navigateByDifference(difference)
+														.catch((e: unknown) => {
+															console.log(e);
+														})
+														.finally(() => {
+															this._isNavigatingByToggles = false;
+														});
+												}}
+											></li>`
+									)}
+								</ul>`
+						)}
+					</div>`
+			)}`;
 	}
 }
 

--- a/lit/src/components/perspective-carousel/perspectiveCarousel.ts
+++ b/lit/src/components/perspective-carousel/perspectiveCarousel.ts
@@ -66,8 +66,6 @@ export class PerspectiveCarouselComponent extends LinkedCarouselMixin(LitElement
 	forcedImageHeight = 0;
 	@property({ type: Number })
 	animationLength = 300;
-	@property()
-	centralItemClassName = "active";
 	@property({ type: Boolean })
 	allowSwitchingOrientation = false;
 

--- a/lit/src/docs/lit/backface-carousel/app.ts
+++ b/lit/src/docs/lit/backface-carousel/app.ts
@@ -36,7 +36,7 @@ class BackfaceCarouselApplicationExample1 extends LitElement {
 	static styles = styles;
 
 	render() {
-		return html`<backface-carousel-component>
+		return html`<backface-carousel-component showArrows showToggles allowSwitchingOrientation>
 			<backface-carousel-item-component>
 				<img src=${slide1} alt="Example Image" />
 			</backface-carousel-item-component>
@@ -82,7 +82,7 @@ class BackfaceCarouselApplicationExample2 extends LitElement {
 	static styles = styles;
 
 	render() {
-		return html`<backface-carousel-component isVertical>
+		return html`<backface-carousel-component isVertical showArrows allowSwitchingOrientation>
 			<backface-carousel-item-component>
 				<img src=${slide1} alt="Example Image" />
 			</backface-carousel-item-component>

--- a/lit/src/docs/lit/gallery-carousel/app.ts
+++ b/lit/src/docs/lit/gallery-carousel/app.ts
@@ -27,7 +27,7 @@ const styles = css`
 		display: block;
 		width: 370px;
 		height: 220px;
-		margin: 0 auto 40px;
+		margin: 0 auto 80px;
 	}
 `;
 
@@ -37,7 +37,7 @@ export class GalleryCarouselApplicationExample1 extends LitElement {
 
 	render() {
 		return html`
-			<gallery-carousel-component class="gallery-wrap" showArrows showToggles smoothDiametralTransition>
+			<gallery-carousel-component class="gallery-wrap" showArrows showToggles smoothDiametralTransition allowSwitchingOrientation>
 				<gallery-carousel-item-component>
 					<img class="gallery-item" src=${slide0} alt="Example Image" />
 				</gallery-carousel-item-component>

--- a/lit/src/docs/lit/menu-carousel/app.ts
+++ b/lit/src/docs/lit/menu-carousel/app.ts
@@ -42,7 +42,7 @@ export class MenuCarouselApplicationExample1 extends LitElement {
 
 	render() {
 		return html`
-			<menu-carousel-component farScale="0.6" class="carousel">
+			<menu-carousel-component farScale="0.6" class="carousel" showArrows showToggles>
 				<carousel-item-component>
 					<img class="carousel-item" src=${slide0} alt="Example Image" />
 				</carousel-item-component>

--- a/lit/src/docs/lit/one-page-scroll/index.html
+++ b/lit/src/docs/lit/one-page-scroll/index.html
@@ -49,7 +49,7 @@
       </div>
     </one-page-scroll-component>
     <p>Here is an example of horizontal one-page scroll:</p>
-    <one-page-scroll-component class="one-page-scroll" noScrollbar isHorizontal>
+    <one-page-scroll-component class="one-page-scroll" noScrollbar isHorizontal allowSwitchingOrientation showArrows showToggles>
       <div class="one-page-scroll-slide">
         <p class="one-page-scroll-slide__heading">First slide. Scroll down...</p>
       </div>

--- a/lit/src/docs/lit/one-page-scroll/style.css
+++ b/lit/src/docs/lit/one-page-scroll/style.css
@@ -2,6 +2,11 @@
 	width: 500px;
 	height: 500px;
 	border: 3px solid #333;
+	margin: 0 auto;
+}
+
+.one-page-scroll[allowSwitchingOrientation] {
+	margin-bottom: 80px;
 }
 
 .one-page-scroll-slide {
@@ -18,5 +23,5 @@
 }
 
 one-page-scroll-component:not(:defined) {
-        display: none;
+	display: none;
 }

--- a/lit/src/docs/lit/perspective-carousel/app.ts
+++ b/lit/src/docs/lit/perspective-carousel/app.ts
@@ -26,7 +26,7 @@ import("../../../components/perspective-carousel/perspectiveCarousel")
 export class PerspectiveCarouselApplicationExample1 extends LitElement {
 	render() {
 		return html`
-			<perspective-carousel-component allowSwitchingOrientation>
+			<perspective-carousel-component allowSwitchingOrientation showArrows showToggles>
 				<carousel-item-component hasTransition>
 					<img class="carousel-item" src=${slide0} alt="Example Image" />
 				</carousel-item-component>

--- a/lit/src/docs/lit/perspective-carousel/index.html
+++ b/lit/src/docs/lit/perspective-carousel/index.html
@@ -51,7 +51,6 @@
 					animationLength, specifies the transition between items length in milliseconds. The smooth transition is set through CSS property
 					on images. Defaults to 300.
 				</li>
-				<li>centralItemClassName, gives a class name to the central item. Defaults to "active".</li>
 				<li>allowSwitchingOrientation, a boolean value that allows to switch orientation of carousel through button. Defaults to false.</li>
 			</ul>
 			<p>Here is a carousel only with allowSwitchingOrientation option:</p>

--- a/lit/src/interfaces/generic/carousel.ts
+++ b/lit/src/interfaces/generic/carousel.ts
@@ -39,6 +39,29 @@ export const carouselControlsStyles = css`
 		text-transform: uppercase;
 		cursor: pointer;
 	}
+
+	.carousel-controls__toggles {
+		position: relative;
+		z-index: 2;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		list-style-type: none;
+		padding: 0;
+		gap: 0.3rem;
+	}
+
+	.carousel-controls__toggle {
+		width: 10px;
+		height: 10px;
+		cursor: pointer;
+		border: 1px solid #e2e2e2;
+		border-radius: 50%;
+	}
+
+	.carousel-controls__toggle--active {
+		background-color: #2390bb;
+	}
 `;
 
 export { CarouselDirection };

--- a/lit/src/interfaces/hooks/autoplayController.ts
+++ b/lit/src/interfaces/hooks/autoplayController.ts
@@ -1,0 +1,48 @@
+import { LitElement, ReactiveController } from "lit";
+import { CarouselConfigurationAutoplayOptions, CarouselDirection } from "shared/interfaces/carousel";
+
+export interface AutoplayControllerProps {
+	autoplay?: CarouselConfigurationAutoplayOptions;
+	nextSlide(): void;
+	previousSlide(): void;
+}
+
+export class AutoplayController implements ReactiveController {
+	private timeout?: number;
+	private repetitionsLeft: number;
+
+	constructor(
+		private readonly host: LitElement,
+		private readonly options: AutoplayControllerProps
+	) {
+		this.repetitionsLeft = options.autoplay?.totalRepetitions ?? 0;
+		host.addController(this);
+	}
+
+	abortTimeout() {
+		window.clearTimeout(this.timeout);
+		if (!this.repetitionsLeft) {
+			return;
+		}
+
+		this.timeout = window.setTimeout(() => {
+			if (this.options.autoplay?.direction === CarouselDirection.BACKWARDS) {
+				this.options.previousSlide();
+			} else if (this.options.autoplay?.direction === CarouselDirection.FORWARDS) {
+				this.options.nextSlide();
+			}
+
+			this.repetitionsLeft--;
+			this.host.requestUpdate();
+			this.abortTimeout();
+		}, this.options.autoplay?.delay);
+	}
+
+	hostConnected(): void {
+        this.abortTimeout();
+    }
+
+    hostDisconnected(): void {
+        window.clearTimeout(this.timeout);
+    }
+}

--- a/react/src/components/backface-carousel/BackfaceCarousel.tsx
+++ b/react/src/components/backface-carousel/BackfaceCarousel.tsx
@@ -1,4 +1,4 @@
-import React, { Children, CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+import React, { CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { ContextLinkedItems, ExposedContextFunctions } from "../../../src/interfaces/hooks/useLinkedItem";
 import styles from "./BackfaceCarousel.module.css";
 import carouselControlsStyles from "../../interfaces/generic/CarouselControls.module.css";
@@ -8,6 +8,7 @@ import { WithChildren } from "../../utils/utils";
 import { CarouselConfiguration } from "shared/interfaces/carousel";
 import { GenericReactComponentProps } from "../../interfaces/generic/classNameFallthrough";
 import { useAutoplay } from "../../interfaces/hooks/useAutoplay";
+import { getCurrentItemCallback } from "../../utils/carousel";
 
 export const BackfaceCarousel = ({
 	isVertical = false,
@@ -106,8 +107,7 @@ export const BackfaceCarousel = ({
 	const { abortTimeout } = useAutoplay({ autoplay, nextSlide, previousSlide });
 	useResizeListener(setup);
 
-	const childrenLength = Children.count(children);
-	const realCurrentItem = currentItem % childrenLength;
+	const { realCurrentItem, childrenLength, getCurrentItem } = getCurrentItemCallback({ children, currentItem });
 	return (
 		<ContextLinkedItems ref={linkedItemsContext} onAllElementsLoaded={setup} innerChildren={children}>
 			<div {...props}>
@@ -118,7 +118,7 @@ export const BackfaceCarousel = ({
 				</div>
 				{(showArrows || allowSwitchingOrientation) && (
 					<div className={carouselControlsStyles["carousel-controls"]}>
-						{!showArrows && (
+						{showArrows && (
 							<button
 								className={carouselControlsStyles["carousel-controls__previous-button"]}
 								onClick={() => {
@@ -138,12 +138,12 @@ export const BackfaceCarousel = ({
 								Switch
 							</button>
 						)}
-						{!showArrows && (
+						{showArrows && (
 							<button
 								className={carouselControlsStyles["carousel-controls__next-button"]}
 								onClick={() => {
 									abortTimeout();
-									switchPerspective();
+									nextSlide();
 								}}
 							></button>
 						)}
@@ -157,12 +157,7 @@ export const BackfaceCarousel = ({
 								className={`${carouselControlsStyles["carousel-controls__toggle"]} ${i === realCurrentItem ? carouselControlsStyles["carousel-controls__toggle--active"] : ""}`}
 								onClick={() => {
 									abortTimeout();
-									const currentItemOffset = Math.max(0, currentItem - (childrenLength - 1));
-									if (currentItemOffset && currentItemOffset % childrenLength === 0) {
-										rotateCarousel(Math.floor(currentItemOffset / childrenLength) * childrenLength + i);
-									} else if (currentItemOffset) {
-										rotateCarousel((Math.floor(currentItemOffset / childrenLength) + 1) * childrenLength + i);
-									} else rotateCarousel(i);
+									rotateCarousel(getCurrentItem(i));
 								}}
 							></li>
 						))}

--- a/react/src/components/backface-carousel/BackfaceCarousel.tsx
+++ b/react/src/components/backface-carousel/BackfaceCarousel.tsx
@@ -12,8 +12,8 @@ import { useAutoplay } from "../../interfaces/hooks/useAutoplay";
 export const BackfaceCarousel = ({
 	isVertical = false,
 	allowSwitchingOrientation = true,
-	noArrows = false,
-	noToggles = true,
+	showArrows = true,
+	showToggles = false,
 	autoplay,
 	children,
 	...props
@@ -103,7 +103,7 @@ export const BackfaceCarousel = ({
 		if (linkedItemsContext.current?.wasSetupPerformed()) setup();
 	}, [isHorizontal, setup]);
 
-	useAutoplay({ autoplay, nextSlide, previousSlide });
+	const { abortTimeout } = useAutoplay({ autoplay, nextSlide, previousSlide });
 	useResizeListener(setup);
 
 	const childrenLength = Children.count(children);
@@ -116,26 +116,47 @@ export const BackfaceCarousel = ({
 						{children}
 					</ul>
 				</div>
-				{(!noArrows || allowSwitchingOrientation) && (
+				{(showArrows || allowSwitchingOrientation) && (
 					<div className={carouselControlsStyles["carousel-controls"]}>
-						{!noArrows && (
-							<button className={carouselControlsStyles["carousel-controls__previous-button"]} onClick={previousSlide}></button>
+						{!showArrows && (
+							<button
+								className={carouselControlsStyles["carousel-controls__previous-button"]}
+								onClick={() => {
+									abortTimeout();
+									previousSlide();
+								}}
+							></button>
 						)}
 						{allowSwitchingOrientation && (
-							<button className={carouselControlsStyles["carousel-controls__perspective-button"]} onClick={switchPerspective}>
+							<button
+								className={carouselControlsStyles["carousel-controls__perspective-button"]}
+								onClick={() => {
+									abortTimeout();
+									switchPerspective();
+								}}
+							>
 								Switch
 							</button>
 						)}
-						{!noArrows && <button className={carouselControlsStyles["carousel-controls__next-button"]} onClick={nextSlide}></button>}
+						{!showArrows && (
+							<button
+								className={carouselControlsStyles["carousel-controls__next-button"]}
+								onClick={() => {
+									abortTimeout();
+									switchPerspective();
+								}}
+							></button>
+						)}
 					</div>
 				)}
-				{!noToggles && (
+				{showToggles && (
 					<ul className={carouselControlsStyles["carousel-controls__toggles"]}>
 						{Array.from({ length: childrenLength }, (_, i) => (
 							<li
 								key={i}
 								className={`${carouselControlsStyles["carousel-controls__toggle"]} ${i === realCurrentItem ? carouselControlsStyles["carousel-controls__toggle--active"] : ""}`}
 								onClick={() => {
+									abortTimeout();
 									const currentItemOffset = Math.max(0, currentItem - (childrenLength - 1));
 									if (currentItemOffset && currentItemOffset % childrenLength === 0) {
 										rotateCarousel(Math.floor(currentItemOffset / childrenLength) * childrenLength + i);

--- a/react/src/components/gallery-carousel/GalleryCarousel.module.css
+++ b/react/src/components/gallery-carousel/GalleryCarousel.module.css
@@ -23,6 +23,10 @@
 	z-index: 10;
 }
 
+.gallery-list--vertical {
+	flex-direction: column;
+}
+
 .gallery-item {
 	display: inline-block;
 	width: 100%;

--- a/react/src/components/menu-carousel/MenuCarousel.module.css
+++ b/react/src/components/menu-carousel/MenuCarousel.module.css
@@ -9,3 +9,8 @@
 	z-index: 999;
 	top: 80%;
 }
+
+.carousel-toggles {
+	z-index: 999;
+	top: calc(80% + 40px);
+}

--- a/react/src/components/menu-carousel/MenuCarousel.tsx
+++ b/react/src/components/menu-carousel/MenuCarousel.tsx
@@ -73,7 +73,7 @@ export const MenuCarousel = ({
 	const destRotation = useRef(Math.PI / 2);
 	const frameTimer = useRef<number | undefined>();
 	const xRadiusRef = useRef(xRadiusProp);
-	const yRadiusRef = useRef(yRadiusProp);
+	const yRadiusRef = useRef<number | undefined>(yRadiusProp);
 	const xPosRef = useRef(xPosProp);
 	const yPosRef = useRef(yPosProp);
 	const isVertical = useRef(isVerticalProp);
@@ -101,7 +101,7 @@ export const MenuCarousel = ({
 			assertNonUndefinedDevOnly(xRadiusRef.current);
 			item.moveTo(
 				xPosRef.current + scale * (Math.cos(rotation) * xRadiusRef.current - item.fullWidth / 2),
-				yPosRef.current + scale * sin * yRadiusRef.current + yPosRef.current / 2.3,
+				yPosRef.current + scale * sin * (yRadiusRef.current ?? 1) + yPosRef.current / 2.3,
 				scale
 			);
 		},
@@ -192,12 +192,8 @@ export const MenuCarousel = ({
 
 	const switchOrientation = useCallback(() => {
 		isVertical.current = !isVertical.current;
-		const { xRadius, xPos } = getPositions();
-		xRadius.current = undefined;
-		xPos.current = undefined;
-
-		setupCarousel();
-	}, [setupCarousel]);
+		onResize();
+	}, [onResize]);
 
 	useResizeListener(onResize);
 	const { abortTimeout } = useAutoplay({ autoplay, nextSlide, previousSlide });

--- a/react/src/components/perspective-carousel/PerspectiveCarousel.module.css
+++ b/react/src/components/perspective-carousel/PerspectiveCarousel.module.css
@@ -12,7 +12,7 @@
 .carousel-controls {
 	position: absolute;
 	left: 40%;
-	transform: translateX(-50%);
-	bottom: -5%;
+	transform: translate(-50%, 100%);
+	bottom: 0;
 	z-index: 99;
 }

--- a/react/src/components/perspective-carousel/PerspectiveCarousel.tsx
+++ b/react/src/components/perspective-carousel/PerspectiveCarousel.tsx
@@ -277,6 +277,7 @@ export const PerspectiveCarousel = ({
 						...item.styles,
 						zIndex: itemState.depth ?? ""
 					};
+					
 					assignToItem();
 					if (newPosition === 0) {
 						const timeout = window.setTimeout(() => {

--- a/react/src/docs/react/backface-carousel/Page.tsx
+++ b/react/src/docs/react/backface-carousel/Page.tsx
@@ -22,7 +22,7 @@ const Page = () => {
 				BackfaceCarouselItem component that gives default styling required for this type of carousel, and give width and height set to 100%
 				for all inner items of the backface carousel item components.
 			</p>
-			<BackfaceCarousel>
+			<BackfaceCarousel noToggles={false}>
 				<BackfaceCarouselItem>
 					<img className={styles.image} src={image1} alt="Example Image" />
 				</BackfaceCarouselItem>

--- a/react/src/docs/react/backface-carousel/Page.tsx
+++ b/react/src/docs/react/backface-carousel/Page.tsx
@@ -22,7 +22,7 @@ const Page = () => {
 				BackfaceCarouselItem component that gives default styling required for this type of carousel, and give width and height set to 100%
 				for all inner items of the backface carousel item components.
 			</p>
-			<BackfaceCarousel noToggles={false}>
+			<BackfaceCarousel showToggles>
 				<BackfaceCarouselItem>
 					<img className={styles.image} src={image1} alt="Example Image" />
 				</BackfaceCarouselItem>

--- a/react/src/docs/react/menu-carousel/Page.tsx
+++ b/react/src/docs/react/menu-carousel/Page.tsx
@@ -29,7 +29,7 @@ const Page = () => {
 				The carousel accepts special carousel item components to keep track of all the elements, and automatically detect width and height.
 				Here's an example of the carousel with all default settings except far scale being set to 0.8:
 			</p>
-			<MenuCarousel className={styles["carousel"]} farScale={0.8}>
+			<MenuCarousel className={styles["carousel"]} farScale={0.8} showToggles>
 				<CarouselItem className={styles["carousel-item"]}>
 					<img className={styles.img} src={image1} alt="Example Image" />
 				</CarouselItem>

--- a/react/src/docs/react/one-page-scroll/Page.module.css
+++ b/react/src/docs/react/one-page-scroll/Page.module.css
@@ -3,6 +3,7 @@
 	width: 500px;
 	height: 500px;
 	border: 3px solid #333;
+	margin: 0 auto 24px;
 }
 
 .one-page-scroll-slide {

--- a/react/src/docs/react/one-page-scroll/Page.tsx
+++ b/react/src/docs/react/one-page-scroll/Page.tsx
@@ -45,7 +45,7 @@ const Page = () => {
 				</OnePageScrollItem>
 			</OnePageScroll>
 			<p>Here is an example of horizontal one-page scroll:</p>
-			<OnePageScroll className={styles["one-page-scroll"]} isHorizontal>
+			<OnePageScroll className={styles["one-page-scroll"]} isVertical={false} showArrows showToggles allowSwitchingOrientation>
 				<OnePageScrollItem className={styles["one-page-scroll-slide"]}>
 					<p className={styles["one-page-scroll-slide__heading"]}>First slide. Scroll down...</p>
 				</OnePageScrollItem>

--- a/react/src/docs/react/perspective-carousel/Page.tsx
+++ b/react/src/docs/react/perspective-carousel/Page.tsx
@@ -45,7 +45,6 @@ const Page = () => {
 					animationLength, specifies the transition between items length in milliseconds. The smooth transition is set through CSS property
 					on images. Defaults to 300.
 				</li>
-				<li>centralItemClassName, gives a class name to the central item. Defaults to "active".</li>
 				<li>allowSwitchingOrientation, a boolean value that allows to switch orientation of carousel through button. Defaults to false.</li>
 				<li>
 					movingToCenter, movedToCenter, movingFromCenter: three callbacks that are optional to pass and can be used to react on carousel's
@@ -53,7 +52,7 @@ const Page = () => {
 				</li>
 			</ul>
 			<p>Here is a carousel only with allow switching orientation option:</p>
-			<PerspectiveCarousel allowSwitchingOrientation>
+			<PerspectiveCarousel allowSwitchingOrientation showToggles>
 				<CarouselItem className={styles["carousel-item"]}>
 					<img className={styles.img} src={image1} alt="Example Image" />
 				</CarouselItem>

--- a/react/src/interfaces/generic/CarouselControls.module.css
+++ b/react/src/interfaces/generic/CarouselControls.module.css
@@ -35,3 +35,26 @@
 	text-transform: uppercase;
 	cursor: pointer;
 }
+
+.carousel-controls__toggles {
+	position: relative;
+	z-index: 2;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	list-style-type: none;
+	padding: 0;
+	gap: 0.3rem;
+}
+
+.carousel-controls__toggle {
+	width: 10px;
+	height: 10px;
+	cursor: pointer;
+	border: 1px solid #e2e2e2;
+	border-radius: 50%;
+}
+
+.carousel-controls__toggle--active {
+	background-color: #2390bb;
+}

--- a/react/src/interfaces/hooks/useAutoplay.ts
+++ b/react/src/interfaces/hooks/useAutoplay.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CarouselConfigurationAutoplayOptions, CarouselDirection } from "shared/interfaces/carousel";
 
 export interface UseAutoplayProps {
@@ -10,8 +10,9 @@ export interface UseAutoplayProps {
 export const useAutoplay = ({ autoplay, nextSlide, previousSlide }: UseAutoplayProps) => {
 	const [repetitionsLeft, setRepetitionsLeft] = useState(autoplay?.totalRepetitions ?? 0);
 	const timeout = useRef<number>();
-
-	useEffect(() => {
+	
+	const abortTimeout = useCallback(() => {
+		window.clearTimeout(timeout.current);
 		if (!repetitionsLeft) {
 			return;
 		}
@@ -25,5 +26,14 @@ export const useAutoplay = ({ autoplay, nextSlide, previousSlide }: UseAutoplayP
 
 			setRepetitionsLeft((repetitionsLeft) => repetitionsLeft - 1);
 		}, autoplay?.delay);
-	}, [repetitionsLeft]);
+	}, [repetitionsLeft, autoplay, nextSlide, previousSlide]);
+
+	useEffect(() => {
+		abortTimeout();
+		return () => {
+			window.clearTimeout(timeout.current);
+		};
+	}, [abortTimeout]);
+
+	return { abortTimeout };
 };

--- a/react/src/interfaces/hooks/useAutoplay.ts
+++ b/react/src/interfaces/hooks/useAutoplay.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useState } from "react";
+import { CarouselConfigurationAutoplayOptions, CarouselDirection } from "shared/interfaces/carousel";
+
+export interface UseAutoplayProps {
+	autoplay?: CarouselConfigurationAutoplayOptions;
+	nextSlide(): void;
+	previousSlide(): void;
+}
+
+export const useAutoplay = ({ autoplay, nextSlide, previousSlide }: UseAutoplayProps) => {
+	const [repetitionsLeft, setRepetitionsLeft] = useState(autoplay?.totalRepetitions ?? 0);
+	const timeout = useRef<number>();
+
+	useEffect(() => {
+		if (!repetitionsLeft) {
+			return;
+		}
+
+		timeout.current = window.setTimeout(() => {
+			if (autoplay?.direction === CarouselDirection.BACKWARDS) {
+				previousSlide();
+			} else if (autoplay?.direction === CarouselDirection.FORWARDS) {
+				nextSlide();
+			}
+
+			setRepetitionsLeft((repetitionsLeft) => repetitionsLeft - 1);
+		}, autoplay?.delay);
+	}, [repetitionsLeft]);
+};

--- a/react/src/interfaces/hooks/useInterval.ts
+++ b/react/src/interfaces/hooks/useInterval.ts
@@ -18,7 +18,7 @@ export function useInterval(callback: () => void, timeout: number) {
 		return () => {
 			abortInterval();
 		};
-	}, [restartInterval]);
+	}, []);
 
 	return { abortInterval, restartInterval };
 }

--- a/react/src/interfaces/hooks/useStateWithCallback.ts
+++ b/react/src/interfaces/hooks/useStateWithCallback.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+export const useStateWithCallback = <T>(initialValue: T | (() => T), callback?: (value: T) => void) => {
+	const callbackRef = useRef<(value: T) => void>();
+	const [value, setValue] = useState<T>(initialValue);
+
+	useLayoutEffect(() => {
+		callbackRef.current = callback;
+	}, [callback]);
+
+	useEffect(() => {
+		if (callbackRef.current) {
+			callbackRef.current(value);
+			callbackRef.current = undefined;
+		}
+	}, [value]);
+
+	const setValueCallback = useCallback((newValue: T | ((value: T) => T)) => {
+		callbackRef.current = callback;
+		return setValue(newValue);
+	}, []);
+
+	return [value, setValueCallback] as const;
+};

--- a/react/src/utils/carousel.ts
+++ b/react/src/utils/carousel.ts
@@ -1,5 +1,6 @@
 import React, { Children } from "react";
-
+import { getCurrentItemInfo } from "shared/utils/carousel";
+ 
 export interface GetCurrentItemInfoProps {
 	children: React.ReactNode;
 	currentItem: number;
@@ -7,21 +8,5 @@ export interface GetCurrentItemInfoProps {
 
 export const getCurrentItemCallback = ({ children, currentItem }: GetCurrentItemInfoProps) => {
 	const childrenLength = Children.count(children);
-	let realCurrentItem = currentItem % childrenLength;
-	if (realCurrentItem < 0) {
-		realCurrentItem = childrenLength - Math.abs(realCurrentItem);
-	}
-
-	return {
-		getCurrentItem: (i: number) => {
-			const currentItemOffset = currentItem - (childrenLength - 1);
-			if (currentItemOffset && currentItemOffset % childrenLength === 0) {
-				return Math.floor(currentItemOffset / childrenLength) * childrenLength + i;
-			} else if (currentItemOffset) {
-				return (Math.floor(currentItemOffset / childrenLength) + 1) * childrenLength + i;
-			} else return i;
-		},
-		realCurrentItem,
-		childrenLength
-	};
+	return getCurrentItemInfo({ childrenLength, currentItem });
 };

--- a/react/src/utils/carousel.ts
+++ b/react/src/utils/carousel.ts
@@ -1,0 +1,27 @@
+import React, { Children } from "react";
+
+export interface GetCurrentItemInfoProps {
+	children: React.ReactNode;
+	currentItem: number;
+}
+
+export const getCurrentItemCallback = ({ children, currentItem }: GetCurrentItemInfoProps) => {
+	const childrenLength = Children.count(children);
+	let realCurrentItem = currentItem % childrenLength;
+	if (realCurrentItem < 0) {
+		realCurrentItem = childrenLength - Math.abs(realCurrentItem);
+	}
+
+	return {
+		getCurrentItem: (i: number) => {
+			const currentItemOffset = currentItem - (childrenLength - 1);
+			if (currentItemOffset && currentItemOffset % childrenLength === 0) {
+				return Math.floor(currentItemOffset / childrenLength) * childrenLength + i;
+			} else if (currentItemOffset) {
+				return (Math.floor(currentItemOffset / childrenLength) + 1) * childrenLength + i;
+			} else return i;
+		},
+		realCurrentItem,
+		childrenLength
+	};
+};

--- a/shared/component/galleryCarousel.ts
+++ b/shared/component/galleryCarousel.ts
@@ -1,8 +1,8 @@
-export interface GalleryCarouselConfiguration {
+import { CarouselConfiguration } from "shared/interfaces/carousel";
+
+export interface GalleryCarouselConfiguration extends CarouselConfiguration {
 	smoothDiametralTransition: boolean;
 	current: number;
 	frameGap: number;
 	animationDuration: number;
-	showArrows: boolean;
-	showToggles: boolean;
 }

--- a/shared/component/menuCarousel.ts
+++ b/shared/component/menuCarousel.ts
@@ -33,7 +33,7 @@ export interface MenuCarouselConfiguration extends CarouselConfiguration {
 	xPos?: number;
 	yPos: number;
 	xRadius?: number;
-	yRadius: number;
+	yRadius?: number;
 	farScale: number;
 	speed: number;
 }

--- a/shared/component/menuCarousel.ts
+++ b/shared/component/menuCarousel.ts
@@ -1,3 +1,5 @@
+import { CarouselConfiguration } from "shared/interfaces/carousel";
+
 export abstract class MenuCarouselInternalItem {
 	image: HTMLElement;
 	fullWidth: number;
@@ -27,7 +29,7 @@ export abstract class MenuCarouselInternalItem {
 	abstract setMovingStyle(x: number, y: number, scale: number): void;
 }
 
-export interface MenuCarouselConfiguration {
+export interface MenuCarouselConfiguration extends CarouselConfiguration {
 	xPos?: number;
 	yPos: number;
 	xRadius?: number;

--- a/shared/component/onePageScroll.ts
+++ b/shared/component/onePageScroll.ts
@@ -1,5 +1,6 @@
-export interface OnePageScrollConfiguration {
-	isHorizontal: boolean;
+import { CarouselConfiguration } from "shared/interfaces/carousel";
+
+export interface OnePageScrollConfiguration extends CarouselConfiguration {
 	duration: number;
 	increment: number;
 	noScrollbar: boolean;

--- a/shared/component/perspectiveCarousel.ts
+++ b/shared/component/perspectiveCarousel.ts
@@ -1,4 +1,4 @@
-import { CarouselDirection } from "../interfaces/carousel";
+import { CarouselConfiguration, CarouselDirection } from "../interfaces/carousel";
 
 export interface InternalPerspectiveCarouselState<T> {
 	totalItems: number;
@@ -39,7 +39,7 @@ export const resetInternalState = <T>(): InternalPerspectiveCarouselState<T> => 
 	performingSetup: true
 });
 
-export interface PerspectiveCarouselConfiguration {
+export interface PerspectiveCarouselConfiguration extends CarouselConfiguration {
 	imageSize: string;
 	margin: string;
 	startingItem: number;
@@ -51,12 +51,9 @@ export interface PerspectiveCarouselConfiguration {
 	opacityMultiplier: number;
 	horizon: number;
 	flankingItems: number;
-	isVertical: boolean;
 	forcedImageWidth: number;
 	forcedImageHeight: number;
 	animationLength: number;
-	centralItemClassName: string;
-	allowSwitchingOrientation: boolean;
 }
 
 export interface PerspectiveCarouselItemState {

--- a/shared/interfaces/carousel.ts
+++ b/shared/interfaces/carousel.ts
@@ -14,7 +14,7 @@ export interface CarouselConfigurationAutoplayOptions {
 export interface CarouselConfiguration {
 	isVertical?: boolean;
 	allowSwitchingOrientation?: boolean;
-	noArrows?: boolean;
-	noToggles?: boolean;
+	showArrows?: boolean;
+	showToggles?: boolean;
 	autoplay?: CarouselConfigurationAutoplayOptions | undefined; 
 }

--- a/shared/interfaces/carousel.ts
+++ b/shared/interfaces/carousel.ts
@@ -5,3 +5,16 @@ export const CarouselDirection = {
 } as const;
 
 export type CarouselDirection = (typeof CarouselDirection)[keyof typeof CarouselDirection];
+export interface CarouselConfigurationAutoplayOptions {
+	delay: number;
+	totalRepetitions: number;
+	direction: CarouselDirection;
+}
+
+export interface CarouselConfiguration {
+	isVertical?: boolean;
+	allowSwitchingOrientation?: boolean;
+	noArrows?: boolean;
+	noToggles?: boolean;
+	autoplay?: CarouselConfigurationAutoplayOptions | undefined; 
+}

--- a/shared/utils/carousel.ts
+++ b/shared/utils/carousel.ts
@@ -1,0 +1,24 @@
+export interface GetCurrentItemInfoConfiguration {
+	childrenLength: number;
+	currentItem: number;
+}
+
+export const getCurrentItemInfo = ({ childrenLength, currentItem }: GetCurrentItemInfoConfiguration) => {
+	let realCurrentItem = currentItem % childrenLength;
+	if (realCurrentItem < 0) {
+		realCurrentItem = childrenLength - Math.abs(realCurrentItem);
+	}
+
+	return {
+		getCurrentItem: (i: number) => {
+			const currentItemOffset = currentItem - (childrenLength - 1);
+			if (currentItemOffset && currentItemOffset % childrenLength === 0) {
+				return Math.floor(currentItemOffset / childrenLength) * childrenLength + i;
+			} else if (currentItemOffset) {
+				return (Math.floor(currentItemOffset / childrenLength) + 1) * childrenLength + i;
+			} else return i;
+		},
+		realCurrentItem,
+		childrenLength
+	};
+};

--- a/vue/src/components/backface-carousel/BackfaceCarousel.vue
+++ b/vue/src/components/backface-carousel/BackfaceCarousel.vue
@@ -8,122 +8,171 @@
         <slot />
       </ul>
     </div>
-    <div class="carousel-controls">
+    <div
+      v-if="showArrows || showToggles"
+      class="carousel-controls"
+    >
       <button
+        v-if="showArrows"
         class="carousel-controls__previous-button"
-        @click="previousSlide"
+        @click="onPreviousSlide"
       />
       <button
+        v-if="allowSwitchingOrientation"
         class="carousel-controls__perspective-button"
         @click="switchPerspective"
       >
         Switch
       </button>
       <button
+        v-if="showArrows"
         class="carousel-controls__next-button"
-        @click="nextSlide"
+        @click="onNextSlide"
       />
     </div>
+    <ul
+      v-if="showToggles"
+      class="carousel-controls__toggles"
+    >
+      <li
+        v-for="i in currentItemSettings.childrenLength"
+        :key="i"
+        class="carousel-controls__toggle"
+        :class="{ 'carousel-controls__toggle--active': currentItemSettings.realCurrentItem === i - 1 }"
+        @click="() => {
+          abortTimeout();
+          rotateCarousel(currentItemSettings.getCurrentItem(i - 1));
+        }"
+      />
+    </ul>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, reactive, CSSProperties } from "vue";
+import { ref, onMounted, onUnmounted, reactive, CSSProperties, computed } from "vue";
 import { useInjectedLinkedItems } from "../../interfaces/hooks/useLinkedItem";
+import { CarouselConfiguration } from "shared/interfaces/carousel";
+import { getCurrentItemInfo } from "shared/utils/carousel";
+import { useAutoplay } from "../../interfaces/hooks/useAutoplay";
 
-const props = defineProps<{ isVertical?: boolean }>();
+const props = withDefaults(
+  defineProps<CarouselConfiguration>(),
+  {
+    isVertical: false,
+    allowSwitchingOrientation: true,
+    showArrows: true,
+    showToggles: false,
+  }
+);
+
 const isHorizontal = ref(!props.isVertical);
 const elements = useInjectedLinkedItems();
 const carouselStyles = reactive<CSSProperties>({});
 const currentItem = ref(0);
 const interval = ref<number | undefined>(undefined);
 
+const currentItemSettings = computed(() => {
+  return getCurrentItemInfo({ childrenLength: Object.keys(elements).length, currentItem: currentItem.value });
+});
+
 const rotateCarousel = (newCurrentImage: number) => {
-    const items = Object.values(elements);
-    const length = items.length,
-        theta = (2 * Math.PI) / length;
-    carouselStyles.transform = `rotate${isHorizontal.value ? "Y" : "X"}(${String(newCurrentImage * -theta)}rad)`;
-    currentItem.value = newCurrentImage;
+  const items = Object.values(elements);
+  const length = items.length,
+    theta = (2 * Math.PI) / length;
+  carouselStyles.transform = `rotate${isHorizontal.value ? "Y" : "X"}(${String(newCurrentImage * -theta)}rad)`;
+  currentItem.value = newCurrentImage;
 };
 
 const setupCarousel = () => {
-    const items = Object.values(elements);
-    const length = items.length,
-        theta = (2 * Math.PI) / length,
-        size = parseFloat(getComputedStyle(items[0].element)[isHorizontal.value ? "width" : "height"]);
-    const apothem = size / (2 * Math.tan(Math.PI / length));
-    carouselStyles.transformOrigin = `50% 50% ${String(-apothem)}px`;
+  const items = Object.values(elements);
+  const length = items.length,
+    theta = (2 * Math.PI) / length,
+    size = parseFloat(getComputedStyle(items[0].element)[isHorizontal.value ? "width" : "height"]);
+  const apothem = size / (2 * Math.tan(Math.PI / length));
+  carouselStyles.transformOrigin = `50% 50% ${String(-apothem)}px`;
 
-    for (let i = 0; i < length; i++) {
-        items[i].styles = {};
-        items[i].styles.padding = "0";
-        if (i === 0) continue;
-        items[i].styles.transformOrigin = `50% 50% ${String(-apothem)}px`;
-        items[i].styles.transform = `rotate${isHorizontal.value ? "Y" : "X"}(${String(i * theta)}rad)`;
-    }
+  for (let i = 0; i < length; i++) {
+    items[i].styles = {};
+    items[i].styles.padding = "0";
+    if (i === 0) continue;
+    items[i].styles.transformOrigin = `50% 50% ${String(-apothem)}px`;
+    items[i].styles.transform = `rotate${isHorizontal.value ? "Y" : "X"}(${String(i * theta)}rad)`;
+  }
 
-    rotateCarousel(currentItem.value);
+  rotateCarousel(currentItem.value);
 };
 
 const nextSlide = () => {
-    rotateCarousel(currentItem.value + 1);
-    window.clearInterval(interval.value);
-    interval.value = undefined;
+  rotateCarousel(currentItem.value + 1);
+  window.clearInterval(interval.value);
+  interval.value = undefined;
 };
 
 const previousSlide = () => {
-    rotateCarousel(currentItem.value - 1);
-    window.clearInterval(interval.value);
-    interval.value = undefined;
+  rotateCarousel(currentItem.value - 1);
+  window.clearInterval(interval.value);
+  interval.value = undefined;
+};
+
+const { abortTimeout } = useAutoplay({ autoplay: props.autoplay, nextSlide, previousSlide });
+
+const onNextSlide = () => {
+  abortTimeout();
+  nextSlide();
+};
+
+const onPreviousSlide = () => {
+  abortTimeout();
+  previousSlide();
 };
 
 const switchPerspective = () => {
-    isHorizontal.value = !isHorizontal.value;
-    setupCarousel();
-    window.clearInterval(interval.value);
-    interval.value = undefined;
+  isHorizontal.value = !isHorizontal.value;
+  setupCarousel();
+  window.clearInterval(interval.value);
+  interval.value = undefined;
 };
 
 onMounted(() => {
+  setupCarousel();
+  interval.value = window.setInterval(() => {
     setupCarousel();
-    interval.value = window.setInterval(() => {
-        setupCarousel();
-    }, 250);
-    window.addEventListener("resize", setupCarousel);
+  }, 250);
+  window.addEventListener("resize", setupCarousel);
 });
 
 onUnmounted(() => {
-    window.removeEventListener("resize", setupCarousel);
-    window.clearInterval(interval.value);
+  window.removeEventListener("resize", setupCarousel);
+  window.clearInterval(interval.value);
 });
 </script>
 
 <style scoped src="../../interfaces/generic/carousel/carouselControlStyles.css"></style>
 <style scoped>
 .backface-carousel {
-    display: flex;
-    width: auto;
-    height: 100%;
-    flex-direction: column;
-    align-items: center;
-    perspective: 500px;
-    overflow: hidden;
-    padding: 20px;
+  display: flex;
+  width: auto;
+  height: 100%;
+  flex-direction: column;
+  align-items: center;
+  perspective: 500px;
+  overflow: hidden;
+  padding: 20px;
 }
 
 .backface-carousel--vertical {
-    margin-top: 10%;
-    height: 33vw;
-    overflow: visible;
+  margin-top: 10%;
+  height: 33vw;
+  overflow: visible;
 }
 
 .backface-carousel-items {
-    width: 40%;
-    flex: 0 0 auto;
-    margin: 0;
-    transform-style: preserve-3d;
-    transition: all 0.5s;
-    padding: 0;
-    list-style-type: none;
+  width: 40%;
+  flex: 0 0 auto;
+  margin: 0;
+  transform-style: preserve-3d;
+  transition: all 0.5s;
+  padding: 0;
+  list-style-type: none;
 }
 </style>

--- a/vue/src/components/backface-carousel/BackfaceCarousel.vue
+++ b/vue/src/components/backface-carousel/BackfaceCarousel.vue
@@ -70,7 +70,6 @@ const elements = useInjectedLinkedItems();
 const carouselStyles = reactive<CSSProperties>({});
 const currentItem = ref(0);
 const interval = ref<number | undefined>(undefined);
-
 const currentItemSettings = computed(() => {
   return getCurrentItemInfo({ childrenLength: Object.keys(elements).length, currentItem: currentItem.value });
 });

--- a/vue/src/components/gallery-carousel/GalleryCarousel.vue
+++ b/vue/src/components/gallery-carousel/GalleryCarousel.vue
@@ -3,6 +3,7 @@
     <div class="gallery">
       <ul
         class="gallery-list"
+        :class="{ 'gallery-list--vertical': isOrientationVertical }"
         :style="galleryListStyle"
       >
         <first-element />
@@ -11,20 +12,20 @@
       </ul>
     </div>
     <div
-      v-if="props.showArrows"
+      v-if="showArrows"
       class="gallery-controls"
     >
       <button
         class="gallery-controls__previous-button"
-        @click="() => { changeCurrentSlide(currentSlide - 1); }"
+        @click="onPreviousSlide"
       />
       <button
         class="gallery-controls__next-button"
-        @click="() => { changeCurrentSlide(currentSlide + 1); }"
+        @click="onNextSlide"
       />
     </div>
     <ul
-      v-if="props.showToggles && itemsLength > 1"
+      v-if="showToggles && itemsLength > 1"
       class="gallery-toggles"
     >
       <li
@@ -35,6 +36,20 @@
         @click="() => { changeCurrentSlide(i); }"
       />
     </ul>
+    <div
+      v-if="allowSwitchingOrientation"
+      class="carousel-controls"
+    >
+      <button
+        class="carousel-controls__perspective-button"
+        @click="() => {
+          abortTimeout();
+          isOrientationVertical = !isOrientationVertical;
+        }"
+      >
+        Switch
+      </button>
+    </div>
   </div>
 </template>
 
@@ -42,31 +57,35 @@
 import { GalleryCarouselConfiguration } from 'shared/component/galleryCarousel';
 import { useInjectedLinkedItems } from '../../interfaces/hooks/useLinkedItem';
 import { computed, ref, createVNode, VNode, onUnmounted, CSSProperties } from 'vue';
+import { useAutoplay } from "../../interfaces/hooks/useAutoplay";
 
 const props = withDefaults(defineProps<Partial<GalleryCarouselConfiguration>>(), {
-    smoothDiametralTransition: true,
-    current: 1,
-    frameGap: 20,
-    animationDuration: 500,
-    showArrows: true,
-    showToggles: true
+  smoothDiametralTransition: true,
+  current: 1,
+  frameGap: 20,
+  animationDuration: 500,
+  showArrows: true,
+  showToggles: true,
+  allowSwitchingOrientation: false,
+  isVertical: false,
 });
 
 const slots = defineSlots<{
-    default(): VNode[];
+  default(): VNode[];
 }>();
 
 const firstElement = () => {
-    const defaultSlot = slots.default();
-    const lastElement = defaultSlot[defaultSlot.length - 1];
-    return createVNode(lastElement.type, lastElement.props, lastElement.children);
+  const defaultSlot = slots.default();
+  const lastElement = defaultSlot[defaultSlot.length - 1];
+  return createVNode(lastElement.type, lastElement.props, lastElement.children);
 };
 
 const lastElement = () => {
-    const firstElement = slots.default()[0];
-    return createVNode(firstElement.type, firstElement.props, firstElement.children);
+  const firstElement = slots.default()[0];
+  return createVNode(firstElement.type, firstElement.props, firstElement.children);
 };
 
+const isOrientationVertical = ref(props.isVertical);
 const currentSlide = ref(props.current);
 const elements = useInjectedLinkedItems();
 const isAnimating = ref(false);
@@ -75,130 +94,155 @@ const interval = ref<number | undefined>();
 const itemsLength = computed(() => Object.keys(elements).length);
 const galleryLeft = ref(currentSlide.value * -100);
 const galleryListStyle = computed<CSSProperties>(() => ({
-    left: `${String(galleryLeft.value)}%`
+  [isOrientationVertical.value ? "top" : "left"]: `${String(galleryLeft.value)}%`
 }));
 
 const checkCurrentSlide = (value: number) => {
-    if (value === 0 || value > itemsLength.value - 2) return value === 0 ? itemsLength.value - 2 : 1;
-	return value;
+  if (value === 0 || value > itemsLength.value - 2) return value === 0 ? itemsLength.value - 2 : 1;
+  return value;
 };
 
 const slideTo = (position: number, newPosition: number) => {
-    isAnimating.value = true;
-    const start = new Date();
-    interval.value = window.setInterval(() => {
-        let progress = (new Date().getTime() - start.getTime()) / props.animationDuration;
-        if (progress > 1) progress = 1;
-        galleryLeft.value = position + Math.abs(newPosition - position) * progress ** 2 * (position > newPosition ? -1 : 1);
-        if (progress === 1) {
-            window.clearInterval(interval.value);
-            isAnimating.value = false;
-            const newSlide = checkCurrentSlide(currentSlide.value);
-            currentSlide.value = newSlide;
-            galleryLeft.value = newSlide * -100;
-        }
-    }, props.frameGap);
+  isAnimating.value = true;
+  const start = new Date();
+  interval.value = window.setInterval(() => {
+    let progress = (new Date().getTime() - start.getTime()) / props.animationDuration;
+    if (progress > 1) progress = 1;
+    galleryLeft.value = position + Math.abs(newPosition - position) * progress ** 2 * (position > newPosition ? -1 : 1);
+    if (progress === 1) {
+      window.clearInterval(interval.value);
+      isAnimating.value = false;
+      const newSlide = checkCurrentSlide(currentSlide.value);
+      currentSlide.value = newSlide;
+      galleryLeft.value = newSlide * -100;
+    }
+  }, props.frameGap);
 };
 
 const changeCurrentSlide = (newSlide: number) => {
-    if (itemsLength.value <= 1) return;
-    if (!props.smoothDiametralTransition) newSlide = checkCurrentSlide(newSlide);
-    const newPosition = newSlide * -100;
-    if (!isAnimating.value && galleryLeft.value !== newPosition) {
-        currentSlide.value = newSlide;
-        slideTo(galleryLeft.value, newPosition);
-    }
+  if (itemsLength.value <= 1) return;
+  if (!props.smoothDiametralTransition) newSlide = checkCurrentSlide(newSlide);
+  const newPosition = newSlide * -100;
+  if (!isAnimating.value && galleryLeft.value !== newPosition) {
+    currentSlide.value = newSlide;
+    slideTo(galleryLeft.value, newPosition);
+  }
+};
+
+const nextSlide = () => {
+  changeCurrentSlide(currentSlide.value + 1); 
+};
+
+const previousSlide = () => {
+  changeCurrentSlide(currentSlide.value - 1); 
+};
+
+const { abortTimeout } = useAutoplay({ autoplay: props.autoplay, nextSlide, previousSlide });
+
+const onNextSlide = () => {
+  abortTimeout();
+  nextSlide();
+};
+
+const onPreviousSlide = () => {
+  abortTimeout();
+  previousSlide();
 };
 
 onUnmounted(() => {
-    window.clearInterval(interval.value);
+  window.clearInterval(interval.value);
 });
 </script>
 
+<style scoped src="../../interfaces/generic/carousel/carouselControlStyles.css"></style>
 <style scoped>
 .wrap {
-    position: relative;
+  position: relative;
 }
 
 .gallery {
-    position: relative;
-    overflow: hidden;
-    width: 100%;
-    height: 100%;
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
 }
 
 .gallery-list {
-    position: relative;
-    display: flex;
-    width: inherit;
-    height: inherit;
-    margin: 0;
-    padding: 0;
-    list-style-type: none;
-    font-size: 0;
-    white-space: nowrap;
-    line-height: 1;
-    z-index: 10;
+	position: relative;
+	display: flex;
+	width: inherit;
+	height: inherit;
+	margin: 0;
+	padding: 0;
+	list-style-type: none;
+	font-size: 0;
+	white-space: nowrap;
+	line-height: 1;
+	z-index: 10;
+}
+
+.gallery-list--vertical {
+	flex-direction: column;
 }
 
 .gallery-item {
-    display: inline-block;
-    width: 100%;
-    height: 100%;
+  display: inline-block;
+  width: 100%;
+  height: 100%;
 }
 
 .gallery-toggles {
-    position: relative;
-    z-index: 2;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    list-style-type: none;
-    padding: 0;
-    gap: 0.3rem;
+  position: relative;
+  z-index: 2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  list-style-type: none;
+  padding: 0;
+  gap: 0.3rem;
 }
 
 .gallery-toggle {
-    width: 10px;
-    height: 10px;
-    cursor: pointer;
-    border: 1px solid #e2e2e2;
-    border-radius: 50%;
+  width: 10px;
+  height: 10px;
+  cursor: pointer;
+  border: 1px solid #e2e2e2;
+  border-radius: 50%;
 }
 
 .gallery-toggle--active {
-    background-color: #2390bb;
+  background-color: #2390bb;
 }
 
 .gallery-controls {
-    position: absolute;
-    z-index: 1;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    left: -10%;
-    right: -10%;
-    top: 0;
-    bottom: 0;
+  position: absolute;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  left: -10%;
+  right: -10%;
+  top: 0;
+  bottom: 0;
 }
 
 .gallery-controls__next-button {
-    width: 0;
-    height: 0;
-    border-style: solid;
-    border-width: 7.5px 0 7.5px 13px;
-    border-color: transparent transparent transparent #fff;
-    background: none;
-    cursor: pointer;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 7.5px 0 7.5px 13px;
+  border-color: transparent transparent transparent #fff;
+  background: none;
+  cursor: pointer;
 }
 
 .gallery-controls__previous-button {
-    width: 0;
-    height: 0;
-    border-style: solid;
-    border-width: 7.5px 13px 7.5px 0;
-    border-color: transparent #fff transparent transparent;
-    background: none;
-    cursor: pointer;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 7.5px 13px 7.5px 0;
+  border-color: transparent #fff transparent transparent;
+  background: none;
+  cursor: pointer;
 }
 </style>

--- a/vue/src/components/menu-carousel/MenuCarousel.vue
+++ b/vue/src/components/menu-carousel/MenuCarousel.vue
@@ -1,14 +1,43 @@
 <template>
   <ul ref="carousel">
     <slot />
-    <li class="carousel-controls">
+    <li
+      v-if="allowSwitchingOrientation || showArrows"
+      class="carousel-controls"
+    >
       <button
+        v-if="showArrows"
         class="carousel-controls__previous-button"
-        @click="goBack"
+        @click="onNextSlide"
       />
       <button
+        v-if="allowSwitchingOrientation"
+        class="carousel-controls__perspective-button"
+        @click="switchOrientation"
+      >
+        Switch
+      </button>
+      <button
+        v-if="showArrows"
         class="carousel-controls__next-button"
-        @click="goForward"
+        @click="onPreviousSlide"
+      />
+    </li>
+    <li
+      v-if="showToggles"
+      class="carousel-toggles carousel-controls__toggles"
+    >
+      <div
+        v-for="i in currentItemSettings.childrenLength"
+        :key="i"
+        class="carousel-controls__toggle"
+        :class="{ 'carousel-controls__toggle--active': currentItemSettings.realCurrentItem === i - 1 }"
+        @click="() => {
+          abortTimeout();
+          const difference = (currentItemSettings.getCurrentItem(i - 1) % currentItemSettings.childrenLength) - (currentItem % currentItemSettings.childrenLength);
+          go(difference);
+          currentItem += difference;
+        }"
       />
     </li>
   </ul>
@@ -18,23 +47,55 @@
 import { MenuCarouselConfiguration, MenuCarouselInternalItem } from 'shared/component/menuCarousel';
 import { useInjectedLinkedItems, LinkedVueItem } from '../../interfaces/hooks/useLinkedItem';
 import { assertNonUndefinedDevOnly } from "shared/utils/utils";
-import { onMounted, onUnmounted, reactive, ref } from 'vue';
+import { computed, onMounted, onUnmounted, reactive, ref } from 'vue';
 import { CarouselDirection } from 'shared/interfaces/carousel';
+import { getCurrentItemInfo } from "shared/utils/carousel";
+import { useAutoplay } from "../../interfaces/hooks/useAutoplay";
 
 const props = withDefaults(defineProps<MenuCarouselConfiguration>(), {
     yPos: 112,
     yRadius: 128,
     farScale: 0.9,
-    speed: 0.11
+    speed: 0.11,
+    showArrows: true,
+    showToggles: false,
+    allowSwitchingOrientation: false,
+    isVertical: false
 });
 
 const rotation = ref(Math.PI / 2);
 const destRotation = ref(Math.PI / 2);
 const frameTimer = ref<number | undefined>();
 const xRadius = ref(props.xRadius);
-const yRadius = ref(props.yRadius);
+const yRadius = ref<number | undefined>(props.yRadius);
 const xPos = ref(props.xPos);
 const yPos = ref(props.yPos);
+const currentItem = ref(0);
+const isVertical = ref(props.isVertical);
+const currentItemSettings = computed(() => {
+    return getCurrentItemInfo({ childrenLength: Object.keys(elements).length, currentItem: currentItem.value });
+});
+
+const orientationXRadius = computed({
+    get() {
+        return isVertical.value ? yRadius.value : xRadius.value
+    },
+    set(newValue: number | undefined) {
+        if (isVertical.value) {
+            yRadius.value = newValue;
+        } else xRadius.value = newValue;
+    }
+});
+const orientationYRadius = computed({
+    get() {
+        return isVertical.value ? xRadius.value : yRadius.value
+    },
+    set(newValue: number | undefined) {
+        if (isVertical.value) {
+            xRadius.value = newValue;
+        } else yRadius.value = newValue;
+    }
+});
 
 const carousel = ref<HTMLElement | null>(null);
 const elements = useInjectedLinkedItems();
@@ -70,7 +131,7 @@ const rotateItem = (itemIndex: number, rotation: number) => {
     assertNonUndefinedDevOnly(xRadius.value);
     item.moveTo(
         xPos.value + scale * (Math.cos(rotation) * xRadius.value - item.fullWidth / 2),
-        yPos.value + scale * sin * yRadius.value + yPos.value / 2.3,
+        yPos.value + scale * sin * (yRadius.value ?? 1) + yPos.value / 2.3,
         scale
     );
 };
@@ -114,8 +175,8 @@ const setupCarousel = () => {
     if (!carousel.value) return;
     xPos.value ??= carousel.value.offsetWidth * 0.5;
     yPos.value = carousel.value.offsetHeight * 0.1;
-    xRadius.value ??= carousel.value.offsetWidth / 2.3;
-    yRadius.value = carousel.value.offsetHeight / 6;
+    orientationXRadius.value ??= carousel.value.offsetWidth / 2.3;
+    orientationYRadius.value = carousel.value.offsetHeight / 6;
     items.splice(0, items.length);
     for (const image of Object.values(elements)) {
         image.element.removeAttribute("style");
@@ -126,17 +187,36 @@ const setupCarousel = () => {
 };
 
 const onResize = () => {
-    xRadius.value = undefined;
+    orientationXRadius.value = undefined;
     xPos.value = undefined;
     setupCarousel();
 };
 
-const goBack = () => {
+const nextSlide = () => {
     go(CarouselDirection.BACKWARDS);
+    currentItem.value--;
 };
 
-const goForward = () => {
+const previousSlide = () => {
     go(CarouselDirection.FORWARDS);
+    currentItem.value++;
+};
+
+const switchOrientation = () => {
+    isVertical.value = !isVertical.value;
+    onResize();
+};
+
+const { abortTimeout } = useAutoplay({ autoplay: props.autoplay, nextSlide: previousSlide, previousSlide: nextSlide });
+
+const onNextSlide = () => {
+    abortTimeout();
+    nextSlide();
+};
+
+const onPreviousSlide = () => {
+    abortTimeout();
+    previousSlide();
 };
 
 onMounted(() => {
@@ -162,5 +242,10 @@ onUnmounted(() => {
 .carousel-controls {
     z-index: 999;
     top: 80%;
+}
+
+.carousel-toggles {
+    z-index: 999;
+    top: calc(80% + 40px);
 }
 </style>

--- a/vue/src/components/one-page-scroll/OnePageScroll.vue
+++ b/vue/src/components/one-page-scroll/OnePageScroll.vue
@@ -3,38 +3,80 @@
     <div
       ref="wrap"
       class="wrap"
-      :class="{ 'wrap--horizontal': isHorizontal, 'wrap--no-scrollbar': noScrollbar }"
+      :class="{ 'wrap--horizontal': !isVertical, 'wrap--no-scrollbar': noScrollbar }"
       @wheel="onWheel"
     >
       <slot />
     </div>
+    <div
+      v-if="allowSwitchingOrientation || showArrows"
+      class="carousel-controls"
+    >
+      <button
+        v-if="showArrows"
+        class="carousel-controls__previous-button"
+        @click="onPreviousSlide"
+      />
+      <button
+        v-if="allowSwitchingOrientation"
+        class="carousel-controls__perspective-button"
+        @click="switchOrientation"
+      >
+        Switch
+      </button>
+      <button
+        v-if="showArrows"
+        class="carousel-controls__next-button"
+        @click="onNextSlide"
+      />
+    </div>
+    <ul
+      v-if="showToggles"
+      class="carousel-controls__toggles"
+    >
+      <li
+        v-for="i in Object.keys(elements).length"
+        :key="i"
+        class="carousel-controls__toggle"
+        :class="{ 'carousel-controls__toggle--active': currentItem === i - 1 }"
+        @click="() => {
+          navigateToItem(i - 1);
+        }"
+      />
+    </ul>
   </article>
 </template>
 
 <script setup lang="ts">
 import { OnePageScrollConfiguration, easeInOutQuad } from "shared/component/onePageScroll";
 import { useInjectedLinkedItems } from "../../interfaces/hooks/useLinkedItem";
-import { computed, onUnmounted, ref } from "vue";
+import { computed, nextTick, onUnmounted, ref } from "vue";
 import { CarouselDirection } from "shared/interfaces/carousel";
+import { useAutoplay } from "../../interfaces/hooks/useAutoplay";
 
 const props = withDefaults(defineProps<Partial<OnePageScrollConfiguration>>(), {
-	isHorizontal: false,
+	isVertical: true,
 	noScrollbar: true,
 	increment: 6,
-	duration: 500
+	duration: 500,
+	allowSwitchingOrientation: false,
+	showArrows: false,
+	showToggles: false
 });
 const elements = useInjectedLinkedItems();
 const elementsLength = computed(() => Object.keys(elements).length);
 const firstElement = computed(() => Object.values(elements)[0].element);
-const selectedItem = ref(0);
+const currentItem = ref(0);
+const previousItem = ref(0);
 const isScrolling = ref(false);
 const wrap = ref<HTMLElement | null>(null);
 const animationTimeout = ref<number | undefined>();
+const isVertical = ref(props.isVertical);
 
 const smoothScrollTo = (to: number) => {
 	if (!wrap.value) return;
 	isScrolling.value = true;
-	const property = props.isHorizontal ? "scrollLeft" : "scrollTop";
+	const property = isVertical.value ? "scrollTop" : "scrollLeft";
 	const start = wrap.value[property],
 		change = to - start;
 	let currentTime = 0;
@@ -60,29 +102,65 @@ const smoothScrollTo = (to: number) => {
 
 const scrollSlide = (direction: CarouselDirection) => {
 	if (isScrolling.value) return;
-	selectedItem.value += direction;
+	currentItem.value += direction;
 	smoothScrollTo(
-		Object.values(elements)[selectedItem.value].element[props.isHorizontal ? "offsetWidth" : "offsetHeight"] * selectedItem.value
+		Object.values(elements)[currentItem.value].element[props.isVertical ? "offsetHeight" : "offsetWidth"] * currentItem.value
 	);
+};
+
+const nextSlide = () => {
+	if (currentItem.value >= elementsLength.value - 1) {
+		if (isScrolling.value) return;
+		currentItem.value = 0;
+		smoothScrollTo(0);
+	} else scrollSlide(CarouselDirection.FORWARDS);
+};
+
+const previousSlide = () => {
+	if (currentItem.value === 0) {
+		if (isScrolling.value || !wrap.value) return;
+		currentItem.value = elementsLength.value - 1;
+		smoothScrollTo(
+			(props.isVertical ? wrap.value.scrollHeight : wrap.value.scrollWidth) -
+			(props.isVertical ? firstElement.value.offsetHeight : firstElement.value.offsetWidth)
+		);
+	} else scrollSlide(CarouselDirection.BACKWARDS);
+};
+
+const { abortTimeout } = useAutoplay({ autoplay: props.autoplay, nextSlide, previousSlide });
+const navigateToItem = (item: number) => {
+	if (isScrolling.value) return;
+	const element = Object.values(elements)[0].element;
+	currentItem.value = item;
+	smoothScrollTo(element[isVertical.value ? "offsetHeight" : "offsetWidth"] * item);
+	abortTimeout();
 };
 
 const onWheel = (event: WheelEvent) => {
 	if (event.deltaY > 0) {
-		if (selectedItem.value >= elementsLength.value - 1) {
-			if (isScrolling.value) return;
-			selectedItem.value = 0;
-			smoothScrollTo(0);
-		} else scrollSlide(CarouselDirection.FORWARDS);
-	} else {
-		if (selectedItem.value === 0) {
-			if (isScrolling.value || !wrap.value) return;
-			selectedItem.value = elementsLength.value - 1;
-			smoothScrollTo(
-				(props.isHorizontal ? wrap.value.scrollWidth : wrap.value.scrollHeight) -
-					(props.isHorizontal ? firstElement.value.offsetWidth : firstElement.value.offsetHeight)
-			);
-		} else scrollSlide(CarouselDirection.BACKWARDS);
-	}
+		nextSlide();
+	} else previousSlide();
+	abortTimeout();
+};
+
+const switchOrientation = async () => {
+	if (isScrolling.value || !wrap.value) return;
+    isVertical.value = !isVertical.value;
+    previousItem.value = currentItem.value;
+	currentItem.value = 0;
+	abortTimeout();
+	await nextTick();
+	navigateToItem(previousItem.value);
+};
+
+const onNextSlide = () => {
+    abortTimeout();
+    nextSlide();
+};
+
+const onPreviousSlide = () => {
+    abortTimeout();
+    previousSlide();
 };
 
 onUnmounted(() => {
@@ -90,6 +168,7 @@ onUnmounted(() => {
 });
 </script>
 
+<style scoped src="../../interfaces/generic/carousel/carouselControlStyles.css"></style>
 <style scoped>
 .wrap {
 	width: 100%;
@@ -108,5 +187,9 @@ onUnmounted(() => {
 
 .wrap--no-scrollbar {
 	overflow: hidden;
+}
+
+.carousel-controls {
+	margin-top: 12px;
 }
 </style>

--- a/vue/src/components/perspective-carousel/PerspectiveCarousel.vue
+++ b/vue/src/components/perspective-carousel/PerspectiveCarousel.vue
@@ -49,7 +49,6 @@ const props = withDefaults(defineProps<Partial<PerspectiveCarouselConfiguration>
 	forcedImageWidth: 0,
 	forcedImageHeight: 0,
 	animationLength: 300,
-	centralItemClassName: "active",
 	allowSwitchingOrientation: false
 });
 const imagesStyles = computed<CSSProperties>(() => ({

--- a/vue/src/docs/vue/backface-carousel/App.vue
+++ b/vue/src/docs/vue/backface-carousel/App.vue
@@ -17,7 +17,7 @@
       you use the predefined BackfaceCarouselItem component that gives default styling required for this type of carousel,
       and give width and height set to 100% for all inner items of the backface carousel item components.
     </p>
-    <backface-carousel-component>
+    <backface-carousel-component show-toggles>
       <carousel-item-component>
         <img
           :src="image1"

--- a/vue/src/docs/vue/gallery-carousel/App.vue
+++ b/vue/src/docs/vue/gallery-carousel/App.vue
@@ -25,7 +25,10 @@
       <li>showToggles: Specifies whether the toggles for switching between items are shown. True by default.</li>
     </ul>
     <p>Here is a carousel with all default options:</p>
-    <gallery-carousel-component class="gallery-wrap">
+    <gallery-carousel-component
+      class="gallery-wrap"
+      allow-switching-orientation
+    >
       <carousel-item-component>
         <img
           :src="image1"
@@ -122,7 +125,7 @@ import image6 from "../../../../../assets/img/slide5.png";
   display: block;
   width: 370px;
   height: 220px;
-  margin: 0 auto 40px;
+  margin: 0 auto 80px;
 }
 
 .gallery-item {

--- a/vue/src/docs/vue/menu-carousel/App.vue
+++ b/vue/src/docs/vue/menu-carousel/App.vue
@@ -26,6 +26,7 @@
     <menu-carousel-component
       class="carousel"
       :far-scale="0.8"
+      show-toggles
     >
       <carousel-item-component class="carousel-item">
         <img

--- a/vue/src/docs/vue/one-page-scroll/App.vue
+++ b/vue/src/docs/vue/one-page-scroll/App.vue
@@ -26,7 +26,12 @@
         noScrollbar: A boolean property that controls whether the scrollbars should be hidden (true) or visible (false). Enabled by default.
       </li>
     </ul>
-    <one-page-scroll-component class="one-page-scroll">
+    <one-page-scroll-component
+      class="one-page-scroll one-page-scroll--with-controls"
+      show-arrows
+      show-toggles
+      allow-switching-orientation
+    >
       <one-page-scroll-item-component class="one-page-scroll-slide">
         <p class="one-page-scroll-slide__heading">
           First slide. Scroll down...
@@ -51,7 +56,7 @@
     <p>Here is an example of horizontal one-page scroll:</p>
     <one-page-scroll-component
       class="one-page-scroll"
-      is-horizontal
+      :is-vertical="false"
     >
       <one-page-scroll-item-component class="one-page-scroll-slide">
         <p class="one-page-scroll-slide__heading">
@@ -96,6 +101,11 @@ const SidebarComponent = defineAsyncComponent(() => import("../SidebarComponent.
 	width: 500px;
 	height: 500px;
 	border: 3px solid #333;
+  margin: 0 auto;
+}
+
+.one-page-scroll--with-controls {
+  margin-bottom: 80px;
 }
 
 .one-page-scroll-slide {

--- a/vue/src/docs/vue/perspective-carousel/App.vue
+++ b/vue/src/docs/vue/perspective-carousel/App.vue
@@ -56,7 +56,6 @@
         set through CSS property
         on images. Defaults to 300.
       </li>
-      <li>centralItemClassName, gives a class name to the central item. Defaults to "active".</li>
       <li>
         allowSwitchingOrientation, a boolean value that allows to switch orientation of carousel through button.
         Defaults to false.

--- a/vue/src/docs/vue/perspective-carousel/App.vue
+++ b/vue/src/docs/vue/perspective-carousel/App.vue
@@ -62,7 +62,10 @@
       </li>
     </ul>
     <p>Here is a carousel only with allow switching orientation option:</p>
-    <perspective-carousel-component allow-switching-orientation>
+    <perspective-carousel-component
+      allow-switching-orientation
+      show-toggles
+    >
       <carousel-item-component class="carousel-item">
         <img
           :src="image1"

--- a/vue/src/interfaces/generic/carousel/carouselControlStyles.css
+++ b/vue/src/interfaces/generic/carousel/carouselControlStyles.css
@@ -35,3 +35,26 @@
 	text-transform: uppercase;
 	cursor: pointer;
 }
+
+.carousel-controls__toggles {
+	position: relative;
+	z-index: 2;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	list-style-type: none;
+	padding: 0;
+	gap: 0.3rem;
+}
+
+.carousel-controls__toggle {
+	width: 10px;
+	height: 10px;
+	cursor: pointer;
+	border: 1px solid #e2e2e2;
+	border-radius: 50%;
+}
+
+.carousel-controls__toggle--active {
+	background-color: #2390bb;
+}

--- a/vue/src/interfaces/hooks/useAutoplay.ts
+++ b/vue/src/interfaces/hooks/useAutoplay.ts
@@ -1,0 +1,41 @@
+import { CarouselConfigurationAutoplayOptions, CarouselDirection } from "shared/interfaces/carousel";
+import { onMounted, onUnmounted, ref } from "vue";
+
+export interface UseAutoplayProps {
+    autoplay?: CarouselConfigurationAutoplayOptions;
+    nextSlide(): void;
+    previousSlide(): void;
+}
+
+export function useAutoplay(settings?: UseAutoplayProps) {
+    const repetitionsLeft = ref(settings?.autoplay?.totalRepetitions ?? 0);
+    const timeout = ref<number>();
+
+    const abortTimeout = () => {
+        window.clearTimeout(timeout.value);
+        if (!repetitionsLeft.value) {
+            return;
+        }
+
+        timeout.value = window.setTimeout(() => {
+            if (settings?.autoplay?.direction === CarouselDirection.BACKWARDS) {
+                settings?.previousSlide();
+            } else if (settings?.autoplay?.direction === CarouselDirection.FORWARDS) {
+                settings?.nextSlide();
+            }
+
+            repetitionsLeft.value--;
+            abortTimeout();
+        }, settings?.autoplay?.delay);
+    };
+
+    onMounted(() => {
+        abortTimeout();
+    });
+
+    onUnmounted(() => {
+        window.clearTimeout(timeout.value);
+    });
+
+    return { abortTimeout };
+}


### PR DESCRIPTION
## Description

This pull request sets up autoplay, isVertical and full sets of controls for all the five types of carousels implementing the common interface.

## Analysis

Initially, all the unification was done in React, in order to set up base hooks that could be portable both to Lit and Vue. Then, the carousels were ported to Lit, and then to Vue. 

Autoplay was implemented via a hook, the rest of the options are unique per carousel.
In addition, a bug with perspective carousel switching orientation moving forwards was fixed.

## Name of script

- Backface Carousel
- Gallery Carousel
- Menu Carousel
- One Page Scroll
- Perspective Carousel

## Browser Support

Issue occurred in

- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Opera

Possibly following:

- [x] IE
- [x] Safari
- [x] Safari for IOS
